### PR TITLE
Disable clang warning -Wreserved-id-macro

### DIFF
--- a/src/Warnings.hpp
+++ b/src/Warnings.hpp
@@ -26,6 +26,13 @@ THE SOFTWARE.
 
 #if defined(__clang__)
 
+  #if __has_warning("-Wreserved-id-macro")
+    #define ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_RESERVED_ID_MACRO \
+    _Pragma("clang diagnostic ignored \"-Wreserved-id-macro\"")
+  #else
+    #define ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_RESERVED_ID_MACRO
+  #endif
+
   #if __has_warning("-Wunused-local-typedef")
     #define ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_UNUSED_LOCAL_TYPEDEF \
     _Pragma("clang diagnostic ignored \"-Wunused-local-typedef\"")
@@ -63,6 +70,7 @@ THE SOFTWARE.
     _Pragma("clang diagnostic ignored \"-Wunused-parameter\"") \
     _Pragma("clang diagnostic ignored \"-Wused-but-marked-unused\"") \
     _Pragma("clang diagnostic ignored \"-Wweak-vtables\"") \
+    ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_RESERVED_ID_MACRO \
     ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_UNUSED_LOCAL_TYPEDEF
 
   #define RESTORE_WARNINGS \


### PR DESCRIPTION
This warning is triggered when trying to build boost with Xcode 7.1
(clang-700.1.76).

Additionally, ignore -Wunknown-pragmas to continue working on older
versions of clang that don't know -Wreserved-id-macro.

@gck-ableton Please review and merge, thanks!