### PR TITLE
Path based property map building

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ While qmlscene is running you can change `examples/style.css` and watch the
 application update.
 
 
+## Benchmarks
+
+In the `benchmarks` folder there are benchmarks that can be run manually with:
+
+```
+qmltestrunner -input benchmarks/benchmark_*.qml -import qml
+```
+
+
 ## License
 
 Aqt StyleSheets is distributed under the MIT license (see LICENSE).

--- a/benchmarks/A.qml
+++ b/benchmarks/A.qml
@@ -1,0 +1,7 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+
+import QtQuick 2.3
+
+Item {
+    property string dummy
+}

--- a/benchmarks/B.qml
+++ b/benchmarks/B.qml
@@ -1,0 +1,7 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+
+import QtQuick 2.3
+
+Item {
+    property string dummy
+}

--- a/benchmarks/C.qml
+++ b/benchmarks/C.qml
@@ -1,0 +1,7 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+
+import QtQuick 2.3
+
+Item {
+    property string dummy
+}

--- a/benchmarks/D.qml
+++ b/benchmarks/D.qml
@@ -1,0 +1,7 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+
+import QtQuick 2.3
+
+Item {
+    property string dummy
+}

--- a/benchmarks/benchmark_StyleSet.css
+++ b/benchmarks/benchmark_StyleSet.css
@@ -1,0 +1,40 @@
+/* Copyright (c) 2015 Ableton AG, Berlin */
+
+A {
+  something: "a";
+  background: blue;
+}
+
+B {
+  something: "b";
+  background: blue;
+}
+
+C {
+  something: "c";
+  background: blue;
+}
+
+D {
+  something: "d";
+  background: blue;
+}
+
+A B {
+  something: "ab";
+  background: blue;
+}
+
+A B C {
+  something: "abc";
+  background: blue;
+}
+
+A B C D {
+  something: "abcd";
+  background: blue;
+}
+
+A B C D QQuickRectangle {
+  background: red;
+}

--- a/benchmarks/benchmark_StyleSet.qml
+++ b/benchmarks/benchmark_StyleSet.qml
@@ -64,12 +64,6 @@ Item {
                 property string mode
                 property int level: 0
 
-                // The following line is a work-around to force
-                // initialization of StyleSet objects that are not accessed
-                // otherwise in in the tree. This is a bug in the style
-                // engine which will be fixed later in this branch.
-                property string workaround: StyleSet.name
-
                 Loader {
                     property string parentMode: parent.mode
                     property int parentLevel: parent.level

--- a/benchmarks/benchmark_StyleSet.qml
+++ b/benchmarks/benchmark_StyleSet.qml
@@ -1,0 +1,143 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+
+import QtQuick 2.3
+import QtTest 1.0
+
+import Aqt.StyleSheets 1.1
+
+Item {
+    id: scene
+
+    TestCase {
+        id: creation
+        name: "creation"
+
+        StyleEngine {
+            styleSheetSource: "benchmark_StyleSet.css"
+        }
+
+        QtObject {
+            id: globalProperties
+            property QtObject props: QtObject {
+                property color color: "red"
+            }
+        }
+
+        Component {
+            id: siblings
+
+            A {
+                id: rootItem
+
+                property string mode
+
+                B {
+                    C {
+                        D {
+                            Repeater {
+                                model: 10000
+
+                                property Component simpleBindingRect: Rectangle {
+                                    anchors.fill: parent
+                                    color: globalProperties.props.color
+                                }
+
+                                property Component styleSetBindingRect: Rectangle {
+                                    anchors.fill: parent
+                                    color: StyleSet.props.color("background")
+                                }
+
+                                delegate: rootItem.mode == "styleSet"
+                                    ? styleSetBindingRect
+                                    : simpleBindingRect
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Component {
+            id: sharedTreeRoot
+
+            A {
+                property string mode
+                property int level: 0
+
+                // The following line is a work-around to force
+                // initialization of StyleSet objects that are not accessed
+                // otherwise in in the tree. This is a bug in the style
+                // engine which will be fixed later in this branch.
+                property string workaround: StyleSet.name
+
+                Loader {
+                    property string parentMode: parent.mode
+                    property int parentLevel: parent.level
+                    sourceComponent: sharedTree
+                }
+            }
+        }
+
+        Component {
+            id: sharedTree
+
+            B {
+                property string mode: parentMode
+                property int level: parentLevel + 1
+
+                Loader {
+                    property string parentMode: parent.mode
+                    property int parentLevel: parent.level
+                    sourceComponent: level < 2000 ? sharedTree : leaves
+                }
+
+                Component {
+                    id: leaves
+                    C {
+                        Repeater {
+                            model: 4
+
+                            property Component simpleBindingRect: Rectangle {
+                                anchors.fill: parent
+                                color: globalProperties.props.color
+                            }
+
+                            property Component styleSetBindingRect: Rectangle {
+                                anchors.fill: parent
+                                color: StyleSet.props.color("background")
+                            }
+
+                            delegate: mode == "styleSet"
+                                ? styleSetBindingRect
+                                : simpleBindingRect
+                        }
+                    }
+                }
+            }
+        }
+
+        function benchmark_once_creationOfSiblingsWithSimpleBinding() {
+            var obj = siblings.createObject(creation, { mode: "simple" });
+            obj.destroy();
+        }
+
+        function benchmark_once_creationOfSiblingsWithStyleSetBinding() {
+            var obj = siblings.createObject(creation, { mode: "styleSet" });
+            obj.destroy();
+        }
+
+        function benchmark_once_creationOfSharedTreeWithSimpleBinding() {
+            var obj = sharedTreeRoot.createObject(creation, { mode: "simple" });
+            obj.destroy();
+        }
+
+        function benchmark_once_creationOfSharedTreeWithStyleSetBinding() {
+            var obj = sharedTreeRoot.createObject(creation, { mode: "styleSet" });
+            obj.destroy();
+        }
+
+        function cleanup() {
+            gc();
+        }
+    }
+}

--- a/src/Convert.hpp
+++ b/src/Convert.hpp
@@ -36,7 +36,6 @@ RESTORE_WARNINGS
 
 #include <string>
 
-
 namespace aqt
 {
 namespace stylesheets

--- a/src/Property.hpp
+++ b/src/Property.hpp
@@ -96,7 +96,6 @@ public:
   PropertyValues mValues;
 };
 
-
 } // namespace stylesheets
 } // namespace aqt
 

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -68,7 +68,6 @@ void setGlobalStyleEngine(StyleEngine* pEngine)
 
 StyleEngine::StyleEngine(QObject* pParent)
   : QObject(pParent)
-  , mChangeCount(0)
   , mFontIdCache(StyleEngineHost::globalStyleEngineHost()->fontIdCache())
   , mStylesDir(this)
 {
@@ -79,11 +78,6 @@ StyleEngine::StyleEngine(QObject* pParent)
           &StyleEngine::availableStylesChanged);
   connect(&mStylesDir, &StylesDirWatcher::fileExtensionsChanged, this,
           &StyleEngine::fileExtensionsChanged);
-}
-
-int StyleEngine::changeCount() const
-{
-  return mChangeCount;
 }
 
 QUrl StyleEngine::styleSheetSource() const
@@ -305,8 +299,7 @@ void StyleEngine::loadStyle()
 
   mpStyleTree = createMatchTree(styleSheet, defaultStyleSheet);
 
-  mChangeCount++;
-  Q_EMIT styleChanged(mChangeCount);
+  Q_EMIT styleChanged();
 }
 
 void StyleEngine::classBegin()

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -200,8 +200,6 @@ public:
   /*! @cond DOXYGEN_IGNORE */
   explicit StyleEngine(QObject* pParent = nullptr);
 
-  int changeCount() const;
-
   QUrl styleSheetSource() const;
   void setStyleSheetSource(const QUrl& url);
 
@@ -257,7 +255,7 @@ public:
 
 Q_SIGNALS:
   /*! Fires when the style sheet is replaced or changed on the disk */
-  void styleChanged(int changeCount);
+  void styleChanged();
   /*! Fires when a new style sheet file name is set to the styleName property */
   void styleNameChanged();
   /*! Fires when a new default style sheet file name is set to the styleName
@@ -330,7 +328,6 @@ private:
 
   std::unique_ptr<IStyleMatchTree> mpStyleTree;
   QFileSystemWatcher mFsWatcher;
-  int mChangeCount;
   StyleEngineHost::FontIdCache& mFontIdCache;
 
   StylesDirWatcher mStylesDir;

--- a/src/StyleMatchTree.cpp
+++ b/src/StyleMatchTree.cpp
@@ -229,15 +229,6 @@ void mergePropSet(MatchNode* parent, int sourceLayer, const PropertySpecSet& ps)
 
 } // anon namespace
 
-void mergeInheritableProperties(PropertyMap& dest, const PropertyMap& src)
-{
-  for (auto const& prop : src) {
-    if (dest.find(prop.first) == dest.end()) {
-      dest.insert(prop);
-    }
-  }
-}
-
 #define DEFAULT_STYLESHEET_LAYER 0
 #define USER_STYLESHEET_LAYER 1
 

--- a/src/StyleMatchTree.hpp
+++ b/src/StyleMatchTree.hpp
@@ -72,7 +72,6 @@ using UiItemPath = std::vector<PathElement>;
 std::ostream& operator<<(std::ostream& os, const UiItemPath& path);
 std::string pathToString(const UiItemPath& path);
 
-
 using PropertyMap = std::map<QString, Property>;
 
 void mergeInheritableProperties(PropertyMap& dest, const PropertyMap& b);

--- a/src/StyleMatchTree.hpp
+++ b/src/StyleMatchTree.hpp
@@ -74,8 +74,6 @@ std::string pathToString(const UiItemPath& path);
 
 using PropertyMap = std::map<QString, Property>;
 
-void mergeInheritableProperties(PropertyMap& dest, const PropertyMap& b);
-
 class IStyleMatchTree
 {
 };

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -376,18 +376,6 @@ void StyleSetAttached::setEngine(StyleEngine* pEngine)
   setupStyle();
 }
 
-void StyleSetAttached::updateStyle()
-{
-  QObject* p = parent();
-
-  StyleEngine* pEngine = StyleEngineHost::globalStyleEngine();
-
-  if (p != nullptr && pEngine != nullptr
-      && mStyle.mChangeCount < pEngine->changeCount()) {
-    setEngine(pEngine);
-  }
-}
-
 void StyleSetAttached::setupStyle()
 {
   mStyle.initStyleSet(mPath, mpEngine);

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -23,22 +23,15 @@ THE SOFTWARE.
 #include "StyleSet.hpp"
 
 #include "Convert.hpp"
-#include "CssParser.hpp"
 #include "Log.hpp"
 #include "StyleEngine.hpp"
-#include "StyleMatchTree.hpp"
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
-#include <QtCore/QUrl>
-#include <QtGui/QColor>
-#include <QtGui/QFont>
 #include <QtQml/QQmlEngine>
 #include <QtQuick/QQuickItem>
-#include <boost/optional.hpp>
 RESTORE_WARNINGS
 
-#include <iostream>
 #include <string>
 
 namespace aqt

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -297,7 +297,7 @@ QUrl StyleSet::url(const QString& key) const
   return url;
 }
 
-void StyleSet::onStyleChanged(int)
+void StyleSet::onStyleChanged()
 {
   loadProperties();
 }

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -154,7 +154,6 @@ PropertyMap effectivePropertyMap(const UiItemPath& path, StyleEngine& engine)
 
 StyleSet::StyleSet(QObject* pParent)
   : QObject(pParent)
-  , mChangeCount(0)
 {
 }
 
@@ -165,7 +164,6 @@ void StyleSet::initStyleSet(const UiItemPath& path, StyleEngine* pEngine)
   if (isDiffEngine || mPath != path) {
     if (mpEngine && isDiffEngine) {
       disconnect(mpEngine, &StyleEngine::styleChanged, this, &StyleSet::onStyleChanged);
-      mChangeCount = 0;
     }
 
     mpEngine = pEngine;
@@ -212,7 +210,7 @@ bool StyleSet::getImpl(Property& prop, const QString& key) const
     return true;
   }
 
-  if (!mpEngine.isNull() && mChangeCount == mpEngine->changeCount()) {
+  if (!mpEngine.isNull()) {
     styleSheetsLogWarning() << "Property " << key.toStdString() << " not found ("
                             << pathToString(mPath) << ")";
     Q_EMIT mpEngine->exception(QString::fromLatin1("propertyNotFound"),
@@ -299,11 +297,9 @@ QUrl StyleSet::url(const QString& key) const
   return url;
 }
 
-void StyleSet::onStyleChanged(int changeCount)
+void StyleSet::onStyleChanged(int)
 {
-  if (mChangeCount != changeCount) {
-    loadProperties();
-  }
+  loadProperties();
 }
 
 void StyleSet::loadProperties()
@@ -314,7 +310,6 @@ void StyleSet::loadProperties()
 
   if (mpEngine) {
     mProperties = mpEngine->matchPath(mPath);
-    mChangeCount = mpEngine->changeCount();
 
     if (!mPath.empty()) {
       PropertyMap inheritedProps(

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -173,7 +173,7 @@ void StyleSet::initStyleSet(const UiItemPath& path, StyleEngine* pEngine)
       connect(mpEngine, &StyleEngine::styleChanged, this, &StyleSet::onStyleChanged);
     }
 
-    loadProperties();
+    onStyleChanged();
   }
 }
 

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -331,34 +331,6 @@ void StyleSet::loadProperties()
   }
 }
 
-const PropertyMap& StyleSet::properties(int changeCount)
-{
-  if (changeCount != mChangeCount) {
-    loadProperties();
-  }
-
-  return mProperties;
-}
-
-QObject* StyleSet::grandParent()
-{
-  QObject* pParent = parent();
-  if (pParent) {
-    if (qobject_cast<StyleSetAttached*>(pParent) != nullptr) {
-      pParent = pParent->parent();
-
-      // asking for the attached style of pParent would return the same
-      // attached style again.  So when traversing the tree up, skip the
-      // current object.
-      if (pParent != nullptr) {
-        pParent = pParent->parent();
-      }
-    }
-  }
-
-  return pParent;
-}
-
 StyleSetAttached::StyleSetAttached(QObject* pParent)
   : QObject(pParent)
   , mpEngine(StyleEngineHost::globalStyleEngine())

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -32,6 +32,7 @@ SUPPRESS_WARNINGS
 #include <QtQuick/QQuickItem>
 RESTORE_WARNINGS
 
+#include <iterator>
 #include <string>
 
 namespace aqt
@@ -140,6 +141,9 @@ public:
 
   bool operator()(QObject* pObj)
   {
+    using std::begin;
+    using std::end;
+
     StyleSetAttached* pStyleSetAttached =
       qobject_cast<StyleSetAttached*>(qmlAttachedPropertiesObject<StyleSet>(pObj, false));
 
@@ -147,7 +151,8 @@ public:
       pStyleSetAttached->updateStyle();
 
       if (StyleSet* pStyle = pStyleSetAttached->props()) {
-        mergeInheritableProperties(mPropertyMap, pStyle->properties(mCurrentChangeCount));
+        auto props = pStyle->properties(mCurrentChangeCount);
+        mPropertyMap.insert(begin(props), end(props));
 
         // since our ancestors style should have been compiled already, stop
         // at it
@@ -328,6 +333,9 @@ void StyleSet::onStyleChanged(int changeCount)
 
 void StyleSet::loadProperties(QObject* pRefObject)
 {
+  using std::begin;
+  using std::end;
+
   if (mpEngine) {
     mProperties = mpEngine->matchPath(mPath);
     mChangeCount = mpEngine->changeCount();
@@ -335,7 +343,7 @@ void StyleSet::loadProperties(QObject* pRefObject)
     if (pRefObject) {
       PropertyMap inheritedProps(
         effectivePropertyMap(pRefObject, mpEngine->changeCount()));
-      mergeInheritableProperties(mProperties, inheritedProps);
+      mProperties.insert(begin(inheritedProps), end(inheritedProps));
     }
 
     QObject* pParent = parent();

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -304,18 +304,8 @@ void StyleSet::onStyleChanged()
 
 void StyleSet::loadProperties()
 {
-  using std::begin;
-  using std::end;
-  using std::prev;
-
   if (mpEngine) {
-    mProperties = mpEngine->matchPath(mPath);
-
-    if (!mPath.empty()) {
-      PropertyMap inheritedProps(
-        effectivePropertyMap({begin(mPath), prev(end(mPath))}, *mpEngine));
-      mProperties.insert(begin(inheritedProps), end(inheritedProps));
-    }
+    mProperties = effectivePropertyMap(mPath, *mpEngine);
 
     QObject* pParent = parent();
     if (qobject_cast<StyleSetAttached*>(pParent) != nullptr) {

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -27,15 +27,15 @@ THE SOFTWARE.
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
+#include <QtCore/QObject>
 #include <QtCore/QPointer>
 #include <QtCore/QString>
+#include <QtCore/QUrl>
 #include <QtCore/QVariant>
 #include <QtGui/QColor>
 #include <QtGui/QFont>
 #include <QtQml/qqml.h>
 RESTORE_WARNINGS
-
-#include <string>
 
 class QQuickItem;
 

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -405,7 +405,7 @@ public:
   Q_REVISION(2) Q_INVOKABLE QUrl url(const QString& key) const;
 
   /*! @cond DOXYGEN_IGNORE */
-  void loadProperties(QObject* pRefObject);
+  void loadProperties();
 
   static StyleSetAttached* qmlAttachedProperties(QObject* pObject);
 

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -438,8 +438,6 @@ private:
   T lookupProperty(Property& def, const QString& key) const;
 
 private:
-  friend class StyleSetAttached;
-
   QPointer<StyleEngine> mpEngine;
   UiItemPath mPath;
   PropertyMap mProperties;
@@ -468,8 +466,6 @@ public:
   StyleSet* props();
 
   QString styleInfo() const;
-
-  void updateStyle();
 
 Q_SIGNALS:
   void propsChanged();

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -189,7 +189,7 @@ public:
   void initStyleSet(const UiItemPath& path, StyleEngine* pEngine);
 
   QString path() const;
-  aqt::stylesheets::StyleSet* props();
+  StyleSet* props();
   /*! @endcond */
 
   /*! Indicates whether this style set has any properties set */
@@ -468,7 +468,7 @@ public:
   void setName(const QString& val);
 
   QString path() const;
-  aqt::stylesheets::StyleSet* props();
+  StyleSet* props();
 
   QString styleInfo() const;
 
@@ -480,7 +480,7 @@ Q_SIGNALS:
   void pathChanged(const QString& path);
 
 private Q_SLOTS:
-  void onStyleEngineChanged(aqt::stylesheets::StyleEngine* pEngine);
+  void onStyleEngineChanged(StyleEngine* pEngine);
   void onParentChanged(QQuickItem* pNewParent);
 
 private:

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -427,7 +427,7 @@ Q_SIGNALS:
 
 public Q_SLOTS:
   /*! @cond DOXYGEN_IGNORE */
-  void onStyleChanged(int changeCount);
+  void onStyleChanged();
 
 private:
   bool getImpl(Property& def, const QString& key) const;

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -441,7 +441,6 @@ private:
   QPointer<StyleEngine> mpEngine;
   UiItemPath mPath;
   PropertyMap mProperties;
-  int mChangeCount;
   /*! @endcond */
 };
 

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -408,8 +408,6 @@ public:
   void loadProperties();
 
   static StyleSetAttached* qmlAttachedProperties(QObject* pObject);
-
-  const PropertyMap& properties(int changeCount);
 /*! @endcond */
 
 Q_SIGNALS:
@@ -432,7 +430,6 @@ public Q_SLOTS:
   void onStyleChanged(int changeCount);
 
 private:
-  QObject* grandParent();
   bool getImpl(Property& def, const QString& key) const;
 
   template <typename T>

--- a/src/test/tst_Convert.cpp
+++ b/src/test/tst_Convert.cpp
@@ -33,7 +33,6 @@ SUPPRESS_WARNINGS
 #include <gtest/gtest.h>
 RESTORE_WARNINGS
 
-
 //========================================================================================
 
 using namespace aqt::stylesheets;

--- a/src/test/tst_CssParser.cpp
+++ b/src/test/tst_CssParser.cpp
@@ -76,7 +76,6 @@ Expression getExpr(const PropertyValues& val, size_t idx, const Expression& def 
   return def;
 }
 
-
 size_t getNumberOfValues(const PropertyValues& val)
 {
   return val.size();

--- a/src/test/tst_UrlUtils.cpp
+++ b/src/test/tst_UrlUtils.cpp
@@ -34,9 +34,7 @@ SUPPRESS_WARNINGS
 #include <gtest/gtest.h>
 RESTORE_WARNINGS
 
-
 using namespace aqt::stylesheets;
-
 
 namespace
 {
@@ -183,7 +181,7 @@ TEST(UrlUtils, resolveResourceUrl_relative_local_with_search_path)
 TEST(UrlUtils, resolveResourceUrl_relative_dotdot_local_with_search_path)
 {
   testWithSandbox([](QTemporaryDir& sandbox) {
-      auto temppath = sandbox.path() + "/";
+    auto temppath = sandbox.path() + "/";
 
     QDir tempDir(temppath);
     tempDir.mkpath(QLatin1String("assets"));
@@ -195,10 +193,8 @@ TEST(UrlUtils, resolveResourceUrl_relative_dotdot_local_with_search_path)
     auto fooAbsPath = fooTempDir.absoluteFilePath("foo/assets/a.css");
     createFile(fooAbsPath);
 
-    auto searchPath = QStringList{
-      tempDir.absoluteFilePath("foo/xyz/"),
-      tempDir.absoluteFilePath("bar/")
-    };
+    auto searchPath =
+      QStringList{tempDir.absoluteFilePath("foo/xyz/"), tempDir.absoluteFilePath("bar/")};
 
     // up-paths (../) are never resolved against search path
     EXPECT_EQ(QUrl("../assets/a.css"),
@@ -211,21 +207,19 @@ TEST(UrlUtils, resolveResourceUrl_relative_dotdot_local_with_search_path)
                 QUrl::fromLocalFile(localFilePath), QUrl("../assets/a.css"), searchPath));
 
     // relative paths starting with '/' must not contain '/../'.  They are returned as-is.
-    EXPECT_EQ(QUrl(),
-              searchForResourceSearchPath(
-                QUrl::fromLocalFile(localFilePath), QUrl("/../assets/a.css"), searchPath));
+    EXPECT_EQ(QUrl(), searchForResourceSearchPath(QUrl::fromLocalFile(localFilePath),
+                                                  QUrl("/../assets/a.css"), searchPath));
 
     // path "/" fails
-    EXPECT_EQ(QUrl(),
-              searchForResourceSearchPath(
-                QUrl::fromLocalFile(localFilePath), QUrl("/"), searchPath));
+    EXPECT_EQ(QUrl(), searchForResourceSearchPath(
+                        QUrl::fromLocalFile(localFilePath), QUrl("/"), searchPath));
   });
 }
 
 TEST(UrlUtils, resolveResourceUrl_non_resolvable_url_is_returned_as_is)
 {
   testWithSandbox([](QTemporaryDir& sandbox) {
-      auto temppath = sandbox.path() + "/";
+    auto temppath = sandbox.path() + "/";
 
     QDir tempDir(temppath);
     auto searchPath = QStringList{tempDir.absoluteFilePath("foo/"),

--- a/tests/Foo/A.qml
+++ b/tests/Foo/A.qml
@@ -1,0 +1,7 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+
+import QtQuick 2.3
+
+Item {
+    property string dummy
+}

--- a/tests/Foo/B.qml
+++ b/tests/Foo/B.qml
@@ -1,0 +1,7 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+
+import QtQuick 2.3
+
+Item {
+    property string dummy
+}

--- a/tests/Foo/C.qml
+++ b/tests/Foo/C.qml
@@ -1,0 +1,7 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+
+import QtQuick 2.3
+
+Item {
+    property string dummy
+}

--- a/tests/Foo/qmldir
+++ b/tests/Foo/qmldir
@@ -1,3 +1,7 @@
 module Foo
 
+A 1.0 A.qml
+B 1.0 B.qml
+C 1.0 C.qml
+
 singleton Bar 1.0 Bar.qml

--- a/tests/TestUtils.cpp
+++ b/tests/TestUtils.cpp
@@ -27,7 +27,6 @@ SUPPRESS_WARNINGS
 #include <QtQml/QQmlComponent>
 RESTORE_WARNINGS
 
-
 namespace aqt
 {
 namespace stylesheets

--- a/tests/inheritance.css
+++ b/tests/inheritance.css
@@ -1,0 +1,36 @@
+/* Copyright (c) 2015 Ableton AG, Berlin */
+
+A {
+  forEveryone: "a";
+  onlyA: "A";
+}
+
+B {
+  forEveryone: "b";
+  onlyB: "B";
+}
+
+C {
+  forEveryone: "c";
+  onlyC: "C";
+}
+
+B C {
+  forEveryone: "bc";
+  onlyBC: "BC";
+}
+
+B > C {
+  forEveryone: "b>c";
+  onlyBdirectC: "B>C";
+}
+
+.custom {
+  forEveryone: "custom";
+  onlyCustom: "CUSTOM";
+}
+
+.custom C {
+  forEveryone: "customC";
+  onlyCustomC: "CUSTOMC";
+}

--- a/tests/test-inheritance.qml
+++ b/tests/test-inheritance.qml
@@ -90,8 +90,7 @@ Item {
                    objectPath: "a.b.a.c", prop: "onlyBdirectC", expectedValue: "" },
                 {  tag: "A/B/A/C, forEveryone",
                    objectPath: "a.b.a.c", prop: "forEveryone", expectedValue: "bc" },
-                {  tag: "FAIL: A/B.custom, onlyA",
-                   expectFail: "Bug: A/B.custom does currently not inherit properties from A",
+                {  tag: "A/B.custom, onlyA",
                    objectPath: "a.b_custom", prop: "onlyA", expectedValue: "A" },
                 {  tag: "A/B.custom, onlyB",
                    objectPath: "a.b_custom", prop: "onlyB", expectedValue: "B" },
@@ -122,20 +121,7 @@ Item {
 
         function test_propertyInheritance(data) {
             AqtTests.Utils.withComponent(styledSceneComponent, scene, {}, function(a) {
-
-                // The following two lines are a work-around to force
-                // initialization of StyleSet objects that are not accessed
-                // otherwise in some test rows. This is a bug in the style
-                // engine which will be fixed later in this branch.
-                a.StyleSet.name;
-                a.b.StyleSet.name;
-
                 var obj = eval(data.objectPath);
-
-                if (data.expectFail) {
-                    expectFail("", data.expectFail);
-                }
-
                 compare(obj.StyleSet.props.string(data.prop), data.expectedValue);
             });
         }

--- a/tests/test-inheritance.qml
+++ b/tests/test-inheritance.qml
@@ -1,0 +1,143 @@
+// Copyright (c) 2015 Ableton AG, Berlin
+
+import QtQuick 2.3
+import QtTest 1.0
+
+import Aqt.StyleSheets 1.1
+import Aqt.Testing 1.0 as AqtTests
+
+import Foo 1.0
+
+Item {
+    id: scene
+
+    StyleEngine {
+        id: styleEngine
+        styleSheetSource: "inheritance.css"
+    }
+
+    Component {
+        id: styledSceneComponent
+
+        A {
+            property alias b: b
+            property alias b_custom: b_custom
+            property alias c: c
+
+            B {
+                id: b
+                property alias c: bc
+                property alias a: ba
+
+                C { id: bc }
+
+                A {
+                    id: ba
+                    property alias c: bac
+                    C { id: bac }
+                }
+            }
+
+            B {
+                id: b_custom
+                StyleSet.name: "custom"
+
+                property alias c: b_custom_c
+
+                C { id: b_custom_c }
+            }
+
+            C { id: c }
+        }
+    }
+
+    TestCase {
+        name: "properties are inherited"
+
+        function test_propertyInheritance_data() {
+            return [
+                {  tag: "A, onlyA",
+                   objectPath: "a", prop: "onlyA", expectedValue: "A" },
+                {  tag: "A, forEveryone",
+                   objectPath: "a", prop: "forEveryone", expectedValue: "a" },
+                {  tag: "A/B, onlyA",
+                   objectPath: "a.b", prop: "onlyA", expectedValue: "A" },
+                {  tag: "A/B, onlyB",
+                   objectPath: "a.b", prop: "onlyB", expectedValue: "B" },
+                {  tag: "A/B, forEveryone",
+                   objectPath: "a.b", prop: "forEveryone", expectedValue: "b" },
+                {  tag: "A/B/C, onlyA",
+                   objectPath: "a.b.c", prop: "onlyA", expectedValue: "A" },
+                {  tag: "A/B/C, onlyB",
+                   objectPath: "a.b.c", prop: "onlyB", expectedValue: "B" },
+                {  tag: "A/B/C, onlyC",
+                   objectPath: "a.b.c", prop: "onlyC", expectedValue: "C" },
+                {  tag: "A/B/C, onlyBC",
+                   objectPath: "a.b.c", prop: "onlyBC", expectedValue: "BC" },
+                {  tag: "A/B/C, onlyBdirectC",
+                   objectPath: "a.b.c", prop: "onlyBdirectC", expectedValue: "B>C" },
+                {  tag: "A/B/C, forEveryone",
+                   objectPath: "a.b.c", prop: "forEveryone", expectedValue: "b>c" },
+                {  tag: "A/B/A/C, onlyA",
+                   objectPath: "a.b.a.c", prop: "onlyA", expectedValue: "A" },
+                {  tag: "A/B/A/C, onlyB",
+                   objectPath: "a.b.a.c", prop: "onlyB", expectedValue: "B" },
+                {  tag: "A/B/A/C, onlyC",
+                   objectPath: "a.b.a.c", prop: "onlyC", expectedValue: "C" },
+                {  tag: "A/B/A/C, onlyBC",
+                   objectPath: "a.b.a.c", prop: "onlyBC", expectedValue: "BC" },
+                {  tag: "A/B/A/C, onlyBdirectC",
+                   objectPath: "a.b.a.c", prop: "onlyBdirectC", expectedValue: "" },
+                {  tag: "A/B/A/C, forEveryone",
+                   objectPath: "a.b.a.c", prop: "forEveryone", expectedValue: "bc" },
+                {  tag: "FAIL: A/B.custom, onlyA",
+                   expectFail: "Bug: A/B.custom does currently not inherit properties from A",
+                   objectPath: "a.b_custom", prop: "onlyA", expectedValue: "A" },
+                {  tag: "A/B.custom, onlyB",
+                   objectPath: "a.b_custom", prop: "onlyB", expectedValue: "B" },
+                {  tag: "A/B.custom, onlyCustom",
+                   objectPath: "a.b_custom", prop: "onlyCustom", expectedValue: "CUSTOM" },
+                {  tag: "A/B.custom, forEveryone",
+                   objectPath: "a.b_custom", prop: "forEveryone", expectedValue: "custom" },
+                {  tag: "A/B.custom/C, onlyA",
+                   objectPath: "a.b_custom.c", prop: "onlyA", expectedValue: "A" },
+                {  tag: "A/B.custom/C, onlyB",
+                   objectPath: "a.b_custom.c", prop: "onlyB", expectedValue: "B" },
+                {  tag: "A/B.custom/C, onlyCustom",
+                   objectPath: "a.b_custom.c", prop: "onlyCustom", expectedValue: "CUSTOM" },
+                {  tag: "A/B.custom/C, onlyCustomC",
+                   objectPath: "a.b_custom.c", prop: "onlyCustomC", expectedValue: "CUSTOMC" },
+                {  tag: "A/B.custom/C, forEveryone",
+                   objectPath: "a.b_custom.c", prop: "forEveryone", expectedValue: "customC" },
+                {  tag: "A/C, onlyA",
+                   objectPath: "a.c", prop: "onlyA", expectedValue: "A" },
+                {  tag: "A/C, onlyC",
+                   objectPath: "a.c", prop: "onlyC", expectedValue: "C" },
+                {  tag: "A/C, onlyBC",
+                   objectPath: "a.c", prop: "onlyBC", expectedValue: "" },
+                {  tag: "A/C, forEveryone",
+                   objectPath: "a.c", prop: "forEveryone", expectedValue: "c" },
+            ];
+        }
+
+        function test_propertyInheritance(data) {
+            AqtTests.Utils.withComponent(styledSceneComponent, scene, {}, function(a) {
+
+                // The following two lines are a work-around to force
+                // initialization of StyleSet objects that are not accessed
+                // otherwise in some test rows. This is a bug in the style
+                // engine which will be fixed later in this branch.
+                a.StyleSet.name;
+                a.b.StyleSet.name;
+
+                var obj = eval(data.objectPath);
+
+                if (data.expectFail) {
+                    expectFail("", data.expectFail);
+                }
+
+                compare(obj.StyleSet.props.string(data.prop), data.expectedValue);
+            });
+        }
+    }
+}


### PR DESCRIPTION
This PR builds the property maps by walking up the path hierarchy instead of the Item view/object hierarchy. This is a prerequisite for sharing StyleSets between StyleSetAttached instances. Along the way this fixes some bugs that have been revealed when writing regression tests.

The actual change in commit "Inherit properties by walking the path instead of the view object hierarchy" degrades performance (details in commit message). We expect this to be a non-issue anymore as soon as StyleSets are shared. For that reason, please don't merge until the concept of shared StyleSets has been proven with a following PR that we will notify you about once it is reviewable.

@gck-ableton: please review! Thanks!
@mak-ableton: FYI