### PR TITLE
Make StyleEngine a singleton

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,8 @@ target_link_libraries(StyleSheetParser Qt5::Quick)
 add_library(StylePlugin MODULE
   StyleEngine.cpp
   StyleEngine.hpp
+  StyleEngineSetup.cpp
+  StyleEngineSetup.hpp
   StylePlugin.cpp
   StylePlugin.hpp
   StyleSet.cpp

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -26,7 +26,6 @@ THE SOFTWARE.
 #include "CssParser.hpp"
 #include "Log.hpp"
 #include "StyleMatchTree.hpp"
-#include "StyleSetProps.hpp"
 #include "UrlUtils.hpp"
 #include "Warnings.hpp"
 

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -76,11 +76,6 @@ StyleEngine& StyleEngine::instance()
   return *instanceImpl();
 }
 
-StyleEngine::StyleEngine(QObject* pParent)
-  : QObject(pParent)
-{
-}
-
 void StyleEngine::bindToQmlEngine(QQmlEngine& qmlEngine)
 {
   mBaseUrl = qmlEngine.baseUrl();

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -114,7 +114,6 @@ void StyleEngine::setStyleSheetSource(const QUrl& url)
 {
   if (mStyleSheetSourceUrl != url) {
     mStyleSheetSourceUrl = url;
-    loadStyles();
   }
 }
 
@@ -127,7 +126,6 @@ void StyleEngine::setDefaultStyleSheetSource(const QUrl& url)
 {
   if (mDefaultStyleSheetSourceUrl != url) {
     mDefaultStyleSheetSourceUrl = url;
-    loadStyles();
   }
 }
 

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -89,6 +89,7 @@ StyleEngineHost::FontIdCache& StyleEngineHost::fontIdCache()
 StyleEngine::StyleEngine(QObject* pParent)
   : QObject(pParent)
   , mBaseUrl(qmlEngine(this)->baseUrl())
+  , mImportPaths(qmlEngine(this)->importPathList())
   , mFontIdCache(StyleEngineHost::globalStyleEngineHost()->fontIdCache())
   , mStylesDir(this)
 {
@@ -356,7 +357,7 @@ void StyleEngine::componentComplete()
 
 QUrl StyleEngine::resolveResourceUrl(const QUrl& baseUrl, const QUrl& url) const
 {
-  return searchForResourceSearchPath(baseUrl, url, qmlEngine(this)->importPathList());
+  return searchForResourceSearchPath(baseUrl, url, mImportPaths);
 }
 
 StyleSetProps* StyleEngine::styleSetProps(const UiItemPath& path)

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -155,7 +155,6 @@ void StyleEngine::setStylePath(const QUrl& url)
     mStylePath = qmlEngine(this)->baseUrl().resolved(mStylePathUrl).toLocalFile();
 
     updateSourceUrls();
-    loadStyle();
   }
 }
 

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -267,11 +267,10 @@ void StyleEngine::resolveFontFaceDecl(const StyleSheet& styleSheet)
   }
 }
 
-StyleSheet StyleEngine::loadStyleSheet(const SourceUrl& srcurl)
+StyleSheet StyleEngine::loadStyleSheet(const QUrl& srcurl)
 {
-  if (srcurl.url().isLocalFile() || srcurl.url().isRelative()) {
-    QString styleFilePath =
-      qmlEngine(this)->baseUrl().resolved(srcurl.url()).toLocalFile();
+  if (srcurl.isLocalFile() || srcurl.isRelative()) {
+    QString styleFilePath = qmlEngine(this)->baseUrl().resolved(srcurl).toLocalFile();
 
     if (styleFilePath.isEmpty() || !QFile::exists(styleFilePath)) {
       styleSheetsLogError() << "Style '" << styleFilePath.toStdString() << "' not found";
@@ -313,11 +312,11 @@ void StyleEngine::loadStyles()
   StyleSheet defaultStyleSheet;
 
   if (!mStyleSheetSourceUrl.isEmpty()) {
-    styleSheet = loadStyleSheet(mStyleSheetSourceUrl);
+    styleSheet = loadStyleSheet(mStyleSheetSourceUrl.url());
   }
 
   if (!mDefaultStyleSheetSourceUrl.isEmpty()) {
-    defaultStyleSheet = loadStyleSheet(mDefaultStyleSheetSourceUrl);
+    defaultStyleSheet = loadStyleSheet(mDefaultStyleSheetSourceUrl.url());
   }
 
   mpStyleTree = createMatchTree(styleSheet, defaultStyleSheet);

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -106,7 +106,7 @@ StyleEngine::~StyleEngine()
 {
   for (auto& element : mStyleSetPropsByPath) {
     auto& pStyleSetProps = element.second;
-    Q_EMIT pStyleSetProps->invalidated();
+    pStyleSetProps->invalidate();
   }
 }
 

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -59,29 +59,21 @@ FontIdCache& fontIdCache()
   return sFontIdCache;
 }
 
-std::unique_ptr<StyleEngine>& globalStyleEngineImpl()
+std::unique_ptr<StyleEngine>& instanceImpl()
 {
-  static std::unique_ptr<StyleEngine> sGlobalStyleEngine;
-
-  if (!sGlobalStyleEngine) {
-    sGlobalStyleEngine = estd::make_unique<StyleEngine>();
-  }
-
-  return sGlobalStyleEngine;
+  static std::unique_ptr<StyleEngine> spInstance;
+  return spInstance;
 }
 
 } // anon namespace
 
-StyleEngineHost* StyleEngineHost::globalStyleEngineHost()
+StyleEngine& StyleEngine::instance()
 {
-  static StyleEngineHost gGlobalStyleEngineHost;
+  if (!instanceImpl()) {
+    instanceImpl().reset(new StyleEngine);
+  }
 
-  return &gGlobalStyleEngineHost;
-}
-
-StyleEngine* StyleEngineHost::globalStyleEngine()
-{
-  return globalStyleEngineImpl().get();
+  return *instanceImpl();
 }
 
 StyleEngine::StyleEngine(QObject* pParent)
@@ -95,7 +87,7 @@ void StyleEngine::bindToQmlEngine(QQmlEngine& qmlEngine)
   mImportPaths = qmlEngine.importPathList();
 
   QObject::connect(
-    &qmlEngine, &QObject::destroyed, [](QObject*) { globalStyleEngineImpl().reset(); });
+    &qmlEngine, &QObject::destroyed, [](QObject*) { instanceImpl().reset(); });
 }
 
 bool StyleEngine::hasStylesLoaded() const

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -88,6 +88,7 @@ StyleEngineHost::FontIdCache& StyleEngineHost::fontIdCache()
 
 StyleEngine::StyleEngine(QObject* pParent)
   : QObject(pParent)
+  , mBaseUrl(qmlEngine(this)->baseUrl())
   , mFontIdCache(StyleEngineHost::globalStyleEngineHost()->fontIdCache())
   , mStylesDir(this)
 {
@@ -270,7 +271,7 @@ void StyleEngine::resolveFontFaceDecl(const StyleSheet& styleSheet)
 StyleSheet StyleEngine::loadStyleSheet(const QUrl& srcurl)
 {
   if (srcurl.isLocalFile() || srcurl.isRelative()) {
-    QString styleFilePath = qmlEngine(this)->baseUrl().resolved(srcurl).toLocalFile();
+    QString styleFilePath = mBaseUrl.resolved(srcurl).toLocalFile();
 
     if (styleFilePath.isEmpty() || !QFile::exists(styleFilePath)) {
       styleSheetsLogError() << "Style '" << styleFilePath.toStdString() << "' not found";

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -118,7 +118,7 @@ void StyleEngine::setStyleSheetSource(const QUrl& url)
   if (mStyleSheetSourceUrl.url() != url) {
     mStyleSheetSourceUrl.set(url, this, mFsWatcher);
 
-    loadStyle();
+    loadStyles();
 
     Q_EMIT styleSheetSourceChanged(url);
   }
@@ -134,7 +134,7 @@ void StyleEngine::setDefaultStyleSheetSource(const QUrl& url)
   if (mDefaultStyleSheetSourceUrl.url() != url) {
     mDefaultStyleSheetSourceUrl.set(url, this, mFsWatcher);
 
-    loadStyle();
+    loadStyles();
 
     Q_EMIT defaultStyleSheetSourceChanged(url);
   }
@@ -228,7 +228,7 @@ std::string StyleEngine::describeMatchedPath(const UiItemPath& path) const
 
 void StyleEngine::onFileChanged(const QString&)
 {
-  loadStyle();
+  loadStyles();
 }
 
 void StyleEngine::resolveFontFaceDecl(const StyleSheet& styleSheet)
@@ -306,7 +306,7 @@ StyleSheet StyleEngine::loadStyleSheet(const SourceUrl& srcurl)
   return StyleSheet();
 }
 
-void StyleEngine::loadStyle()
+void StyleEngine::loadStyles()
 {
   StyleSheet styleSheet;
   StyleSheet defaultStyleSheet;

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -270,7 +270,8 @@ void StyleEngine::resolveFontFaceDecl(const StyleSheet& styleSheet)
 StyleSheet StyleEngine::loadStyleSheet(const SourceUrl& srcurl)
 {
   if (srcurl.url().isLocalFile() || srcurl.url().isRelative()) {
-    QString styleFilePath = srcurl.toLocalFile(this);
+    QString styleFilePath =
+      qmlEngine(this)->baseUrl().resolved(srcurl.url()).toLocalFile();
 
     if (styleFilePath.isEmpty() || !QFile::exists(styleFilePath)) {
       styleSheetsLogError() << "Style '" << styleFilePath.toStdString() << "' not found";
@@ -428,11 +429,6 @@ void StyleEngine::SourceUrl::set(const QUrl& url,
       watcher.addPath(stylePath);
     }
   }
-}
-
-QString StyleEngine::SourceUrl::toLocalFile(StyleEngine* pParent) const
-{
-  return qmlEngine(pParent)->baseUrl().resolved(mSourceUrl).toLocalFile();
 }
 
 } // namespace stylesheets

--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -262,7 +262,7 @@ StyleSetProps* StyleEngine::styleSetProps(const UiItemPath& path)
 
   if (iElement == mStyleSetPropsByPath.end()) {
     std::tie(iElement, std::ignore) =
-      mStyleSetPropsByPath.emplace(path, estd::make_unique<StyleSetProps>(path, this));
+      mStyleSetPropsByPath.emplace(path, estd::make_unique<StyleSetProps>(path));
   }
 
   return iElement->second.get();

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -54,9 +54,6 @@ public:
   static StyleEngineHost* globalStyleEngineHost();
 
   static StyleEngine* globalStyleEngine();
-
-Q_SIGNALS:
-  void styleEngineLoaded(aqt::stylesheets::StyleEngine* pEngine);
 };
 
 /*! @endcond */

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -43,21 +43,6 @@ namespace aqt
 namespace stylesheets
 {
 
-class StyleEngine;
-
-/*! @cond DOXYGEN_IGNORE */
-
-class StyleEngineHost : public QObject
-{
-  Q_OBJECT
-public:
-  static StyleEngineHost* globalStyleEngineHost();
-
-  static StyleEngine* globalStyleEngine();
-};
-
-/*! @endcond */
-
 /*! The singleton StyleEngine
  *
  * Provides css properties that it loads from style sheet source urls.
@@ -71,6 +56,8 @@ class StyleEngine : public QObject
 
 public:
   /*! @cond DOXYGEN_IGNORE */
+  static StyleEngine& instance();
+
   explicit StyleEngine(QObject* pParent = nullptr);
 
   void bindToQmlEngine(QQmlEngine& qmlEngine);

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -58,8 +58,6 @@ public:
   /*! @cond DOXYGEN_IGNORE */
   static StyleEngine& instance();
 
-  explicit StyleEngine(QObject* pParent = nullptr);
-
   void bindToQmlEngine(QQmlEngine& qmlEngine);
 
   QUrl styleSheetSource() const;
@@ -127,6 +125,8 @@ Q_SIGNALS:
   Q_REVISION(1) void exception(const QString& type, const QString& message);
 
 private:
+  StyleEngine() = default;
+
   StyleSheet loadStyleSheet(const QUrl& srcurl);
   void resolveFontFaceDecl(const StyleSheet& styleSheet);
   void reloadAllProperties();

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -337,7 +337,7 @@ private:
     QUrl mSourceUrl;
   };
 
-  StyleSheet loadStyleSheet(const SourceUrl& srcurl);
+  StyleSheet loadStyleSheet(const QUrl& srcurl);
   void resolveFontFaceDecl(const StyleSheet& styleSheet);
   void reloadAllProperties();
 

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -51,19 +51,12 @@ class StyleEngineHost : public QObject
 {
   Q_OBJECT
 public:
-  using FontIdCache = std::map<QString, int>;
-
   static StyleEngineHost* globalStyleEngineHost();
 
   static StyleEngine* globalStyleEngine();
 
-  FontIdCache& fontIdCache();
-
 Q_SIGNALS:
   void styleEngineLoaded(aqt::stylesheets::StyleEngine* pEngine);
-
-private:
-  std::map<QString, int> mFontIdCache;
 };
 
 /*! @endcond */
@@ -170,7 +163,6 @@ private:
   QStringList mImportPaths;
 
   std::unique_ptr<IStyleMatchTree> mpStyleTree;
-  StyleEngineHost::FontIdCache& mFontIdCache;
 
   StyleSetPropsByPath mStyleSetPropsByPath;
 

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -274,6 +274,12 @@ public:
    */
   PropertyMap* properties(const UiItemPath& path);
 
+  /*! Loads the styles from the previously set style sheet sources
+   *
+   * It is safe to call if the sources have not been set yet or have been only partly set.
+   */
+  void loadStyles();
+
 Q_SIGNALS:
   /*! Fires when the style sheet is replaced or changed on the disk */
   void styleChanged();
@@ -332,7 +338,6 @@ private:
     QUrl mSourceUrl;
   };
 
-  void loadStyles();
   StyleSheet loadStyleSheet(const SourceUrl& srcurl);
   void resolveFontFaceDecl(const StyleSheet& styleSheet);
   void reloadAllProperties();

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -360,6 +360,8 @@ private:
   SourceUrl mStyleSheetSourceUrl;
   SourceUrl mDefaultStyleSheetSourceUrl;
 
+  QUrl mBaseUrl;
+
   std::unique_ptr<IStyleMatchTree> mpStyleTree;
   QFileSystemWatcher mFsWatcher;
   StyleEngineHost::FontIdCache& mFontIdCache;

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -361,6 +361,7 @@ private:
   SourceUrl mDefaultStyleSheetSourceUrl;
 
   QUrl mBaseUrl;
+  QStringList mImportPaths;
 
   std::unique_ptr<IStyleMatchTree> mpStyleTree;
   QFileSystemWatcher mFsWatcher;

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -332,7 +332,7 @@ private:
     QUrl mSourceUrl;
   };
 
-  void loadStyle();
+  void loadStyles();
   StyleSheet loadStyleSheet(const SourceUrl& srcurl);
   void resolveFontFaceDecl(const StyleSheet& styleSheet);
   void reloadAllProperties();

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "StyleMatchTree.hpp"
 #include "StylesDirWatcher.hpp"
+#include "StyleSetProps.hpp"
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
@@ -46,7 +47,6 @@ namespace stylesheets
 {
 
 class StyleEngine;
-class StyleSetProps;
 
 /*! @cond DOXYGEN_IGNORE */
 

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -323,7 +323,6 @@ private:
   {
   public:
     void set(const QUrl& url, StyleEngine* pParent, QFileSystemWatcher& watcher);
-    QString toLocalFile(StyleEngine* pParent) const;
 
     QUrl url() const
     {

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -23,23 +23,20 @@ THE SOFTWARE.
 #pragma once
 
 #include "StyleMatchTree.hpp"
-#include "StylesDirWatcher.hpp"
 #include "StyleSetProps.hpp"
 #include "Warnings.hpp"
 
 SUPPRESS_WARNINGS
-#include <QtCore/QDir>
-#include <QtCore/QFileSystemWatcher>
 #include <QtCore/QObject>
 #include <QtCore/QString>
 #include <QtCore/QUrl>
-#include <QtCore/QVariantList>
-#include <QtQml/QQmlParserStatus>
 RESTORE_WARNINGS
 
 #include <memory>
 #include <unordered_map>
 #include <vector>
+
+class QQmlEngine;
 
 namespace aqt
 {
@@ -71,138 +68,22 @@ private:
 
 /*! @endcond */
 
-/*! Interface to the singleton StyleEngine
+/*! The singleton StyleEngine
  *
- * Create and setup the style engine for the application.  There must be a
- * single instance of this class for a complete application only.  Trying
- * to create more than one instance will print a warning leaving the first
- * instance untouched.
+ * Provides css properties that it loads from style sheet source urls.
  *
- * The style engine supports up to two stylesheets specified by the
- * styleSheetSource and defaultStyleSheetSource properties.  Rules from the
- * former take precedence of the those from the later.
- *
- * @par Example
- * @code
- * ApplicationWindow {
- *   StyleEngine {
- *     styleSheetSource: "../Assets/bright.css"
- *     defaultStyleSheetSource: "Resources/default.css"
- *   }
- * }
- * @endcode
- *
- * @par Import in QML:
- * <pre>
- * import Aqt.StyleSheets 1.0
- * </pre>
- * @since 1.0
+ * @see StyleEngineSetup for configuration from QML
  */
-class StyleEngine : public QObject, public QQmlParserStatus
+class StyleEngine : public QObject
 {
   Q_OBJECT
   Q_DISABLE_COPY(StyleEngine)
-  Q_INTERFACES(QQmlParserStatus)
-
-  /*! @public Contains the URL of folder containing style sheets
-   *
-   * The URL is resolved relative to the location of the QML file in which the
-   * StyleEngine is instantiated.  It must resolve to a local file path.  The
-   * StyleEngine is actively watching this folder.  Appearing or disappearing
-   * style sheet file will fire availableStylesChanged() signals.
-   *
-   * @deprecated Use styleSheetSource and defaultStyleSheetSource properties
-   * instead.  For watching folders of style sheets use StylesDirWatcher.
-   */
-  Q_PROPERTY(QUrl stylePath READ stylePath WRITE setStylePath)
-
-  /*! @public Contains the file name of the current style sheet
-   *
-   * The style sheet file is actively watched and, if changing, reloaded.  New
-   * or changing properties will fire styleChanged(int) signals.  There's no
-   * need though to actively monitor this signal since properties requested
-   * via the StyleSet attached type will automatically connect to the style
-   * engine.
-   *
-   * The style sheet file name can be set during app runtime.  This will load
-   * the new style sheet and update all StyleSet.props in the app accordingly.
-   *
-   * @see styleName property
-   *
-   * @deprecated Use styleSheetSource property instead.
-   */
-  Q_PROPERTY(QString styleName READ styleName WRITE setStyleName NOTIFY styleNameChanged)
-
-  /*! @public Contains the file name of the default style sheet
-   *
-   * @see styleName property
-   *
-   * @deprecated Use defaultStyleSheetSource property instead.
-   */
-  Q_PROPERTY(QString defaultStyleName READ defaultStyleName WRITE setDefaultStyleName
-               NOTIFY defaultStyleNameChanged)
-
-  /*! @public Defines the list of support file extensions
-   *
-   * Only files with these extensions will be found as style sheets.  Default
-   * is *.css only.
-   *
-   * @deprecated Use StylesDirWatcher instead.
-   */
-  Q_PROPERTY(QVariantList fileExtensions READ fileExtensions WRITE setFileExtensions
-               NOTIFY fileExtensionsChanged)
-
-  /*! @public Contains the list of all style sheet files found in the
-   * stylePath folder
-   *
-   * Contains all files in the folder given by the stylePath property.
-   * Only files ending in the @c *.css extension are listed.
-   *
-   * Whenever the list of style sheet files in the watch folder (given by the
-   * stylePath property) is changed the availableStylesChanged() signal will
-   * be fired.
-   *
-   * The most like usage of this property is to build a style sheet chooser
-   * (@ref StyleSheetMenu).
-   *
-   * @deprecated Use StylesDirWatcher instead.
-   */
-  Q_PROPERTY(QVariantList availableStyles READ availableStyles NOTIFY
-               availableStylesChanged)
-
-  /*! @public Contains the source url of the current style sheet
-   *
-   * The style sheet file is actively watched and, if changing, reloaded.  New
-   * or changing properties will fire styleChanged(int) signals.  There's no
-   * need though to actively monitor this signal since properties requested
-   * via the StyleSet attached type will automatically connect to the style
-   * engine.
-   *
-   * The style sheet url can be set during app runtime.  This will load the
-   * new style sheet and update all StyleSet.props in the app accordingly.
-   *
-   * The URL is resolved relative to the location of the QML file in which the
-   * StyleEngine is instantiated.
-   *
-   * @since 1.1
-   */
-  Q_PROPERTY(QUrl styleSheetSource READ styleSheetSource WRITE setStyleSheetSource NOTIFY
-               styleSheetSourceChanged REVISION 1)
-
-  /*! @public Contains the source url of the default style sheet
-   *
-   * @see styleSheetSource property
-   *
-   * @since 1.1
-   */
-  Q_PROPERTY(QUrl defaultStyleSheetSource READ defaultStyleSheetSource WRITE
-               setDefaultStyleSheetSource NOTIFY defaultStyleSheetSourceChanged
-                 REVISION 1)
 
 public:
   /*! @cond DOXYGEN_IGNORE */
   explicit StyleEngine(QObject* pParent = nullptr);
-  ~StyleEngine();
+
+  void bindToQmlEngine(QQmlEngine& qmlEngine);
 
   QUrl styleSheetSource() const;
   void setStyleSheetSource(const QUrl& url);
@@ -210,37 +91,9 @@ public:
   QUrl defaultStyleSheetSource() const;
   void setDefaultStyleSheetSource(const QUrl& url);
 
-  /*! @deprecated Use StylesDirWatcher instead. */
-  QUrl stylePath() const;
-  /*! @deprecated Use StylesDirWatcher instead. */
-  void setStylePath(const QUrl& path);
-
-  /*! @deprecated Use styleSheetSource instead. */
-  QString styleName() const;
-  /*! @deprecated Use setStyleSheetSource instead. */
-  void setStyleName(const QString& styleName);
-
-  /*! @deprecated Use defaultStyleSheetSource instead. */
-  QString defaultStyleName() const;
-  /*! @deprecated Use setDefaultStyleSheetSource instead. */
-  void setDefaultStyleName(const QString& styleName);
-
-  /*! @deprecated Use StylesDirWatcher instead */
-  QVariantList fileExtensions() const;
-  /*! @deprecated Use StylesDirWatcher instead */
-  void setFileExtensions(const QVariantList& exts);
-
-  /*! returns a list of URL with available style files
-   *
-   * @deprecated Use StylesDirWatcher instead */
-  QVariantList availableStyles();
-
-  virtual void classBegin();
-  virtual void componentComplete();
-  /*! @endcond */
-
-  /*! @private */
   std::string describeMatchedPath(const UiItemPath& path) const;
+
+  /*! @endcond */
 
   /*! Resolve @p url against @p baseUrl or search for it in a search path.
    *
@@ -255,8 +108,7 @@ public:
    * the same StyleSetProps instance.
    *
    * Will never return nullptr, but pointers will be invalidated if
-   * and only if this StyleEngine instance is destroyed. Clients should
-   * listen to StyleSetProps::invalidated.
+   * and only if this StyleEngine instance is destroyed.
    */
   StyleSetProps* styleSetProps(const UiItemPath& path);
 
@@ -280,30 +132,12 @@ public:
    */
   void loadStyles();
 
+  bool hasStylesLoaded() const;
+  void unloadStyles();
+
 Q_SIGNALS:
   /*! Fires when the style sheet is replaced or changed on the disk */
   void styleChanged();
-  /*! Fires when a new style sheet file name is set to the styleName property */
-  void styleNameChanged();
-  /*! Fires when a new default style sheet file name is set to the styleName
-   * property */
-  void defaultStyleNameChanged();
-  /*! Fires when a new set of file extensions are set to the fileExtensions
-   * property */
-  void fileExtensionsChanged();
-  /*! Fires when the list of style sheets in the stylePath folder changes */
-  void availableStylesChanged();
-
-  /*! Emitted when the style sheet source URL changes.
-   *
-   * @since 1.1
-   */
-  Q_REVISION(1) void styleSheetSourceChanged(const QUrl& url);
-  /*! Emitted when the default style sheet source URL changes.
-   *
-   * @since 1.1
-   */
-  Q_REVISION(1) void defaultStyleSheetSourceChanged(const QUrl& url);
 
   /*! Emitted when any part of the style sheet subsystem has to report some
    *  exceptional situation
@@ -315,33 +149,10 @@ Q_SIGNALS:
    */
   Q_REVISION(1) void exception(const QString& type, const QString& message);
 
-private Q_SLOTS:
-  void onFileChanged(const QString& path);
-
 private:
-  class SourceUrl
-  {
-  public:
-    void set(const QUrl& url, StyleEngine* pParent, QFileSystemWatcher& watcher);
-
-    QUrl url() const
-    {
-      return mSourceUrl;
-    }
-
-    bool isEmpty() const
-    {
-      return mSourceUrl.isEmpty();
-    }
-
-    QUrl mSourceUrl;
-  };
-
   StyleSheet loadStyleSheet(const QUrl& srcurl);
   void resolveFontFaceDecl(const StyleSheet& styleSheet);
   void reloadAllProperties();
-
-  void updateSourceUrls();
 
   PropertyMap* effectivePropertyMap(const UiItemPath& path);
 
@@ -352,27 +163,21 @@ private:
   using PropertyMapInstances = std::vector<std::unique_ptr<PropertyMap>>;
   using PropertyMaps = std::unordered_map<UiItemPath, PropertyMap*, UiItemPathHasher>;
 
-  QUrl mStylePathUrl;        //!< @deprecated
-  QString mStylePath;        //!< @deprecated
-  QString mStyleName;        //!< @deprecated
-  QString mDefaultStyleName; //!< @deprecated
-
-  SourceUrl mStyleSheetSourceUrl;
-  SourceUrl mDefaultStyleSheetSourceUrl;
+  QUrl mStyleSheetSourceUrl;
+  QUrl mDefaultStyleSheetSourceUrl;
 
   QUrl mBaseUrl;
   QStringList mImportPaths;
 
   std::unique_ptr<IStyleMatchTree> mpStyleTree;
-  QFileSystemWatcher mFsWatcher;
   StyleEngineHost::FontIdCache& mFontIdCache;
-
-  StylesDirWatcher mStylesDir;
 
   StyleSetPropsByPath mStyleSetPropsByPath;
 
   PropertyMapInstances mPropertyMapInstances;
   PropertyMaps mPropertyMaps;
+
+  bool mHasStylesLoaded = false;
 };
 
 } // namespace stylesheets

--- a/src/StyleEngineSetup.cpp
+++ b/src/StyleEngineSetup.cpp
@@ -72,6 +72,7 @@ void StyleEngineSetup::setStyleSheetSource(const QUrl& url)
     mStyleSheetSourceUrl.set(url, this, mFsWatcher);
 
     StyleEngine::instance().setStyleSheetSource(url);
+    StyleEngine::instance().loadStyles();
 
     Q_EMIT styleSheetSourceChanged(url);
   }
@@ -88,6 +89,7 @@ void StyleEngineSetup::setDefaultStyleSheetSource(const QUrl& url)
     mDefaultStyleSheetSourceUrl.set(url, this, mFsWatcher);
 
     StyleEngine::instance().setDefaultStyleSheetSource(url);
+    StyleEngine::instance().loadStyles();
 
     Q_EMIT defaultStyleSheetSourceChanged(url);
   }

--- a/src/StyleEngineSetup.cpp
+++ b/src/StyleEngineSetup.cpp
@@ -1,0 +1,213 @@
+/*
+Copyright (c) 2014-2015 Ableton AG, Berlin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "StyleEngineSetup.hpp"
+
+#include "StyleEngine.hpp"
+#include "Warnings.hpp"
+
+SUPPRESS_WARNINGS
+#include <QtCore/QFile>
+#include <QtCore/QDir>
+#include <QtCore/QUrl>
+#include <QtQml/QQmlEngine>
+#include <QtQml/qqml.h>
+RESTORE_WARNINGS
+
+namespace aqt
+{
+namespace stylesheets
+{
+
+StyleEngineSetup::StyleEngineSetup(QObject* pParent)
+  : QObject(pParent)
+  , mStylesDir(this)
+{
+  connect(&mFsWatcher, &QFileSystemWatcher::fileChanged, this,
+          &StyleEngineSetup::onFileChanged);
+
+  connect(&mStylesDir, &StylesDirWatcher::availableStylesChanged, this,
+          &StyleEngineSetup::availableStylesChanged);
+  connect(&mStylesDir, &StylesDirWatcher::fileExtensionsChanged, this,
+          &StyleEngineSetup::fileExtensionsChanged);
+
+  auto* pEngine = StyleEngineHost::globalStyleEngine();
+
+  connect(pEngine, &StyleEngine::styleChanged, this, &StyleEngineSetup::styleChanged);
+  connect(pEngine, &StyleEngine::exception, this, &StyleEngineSetup::exception);
+}
+
+StyleEngineSetup::~StyleEngineSetup()
+{
+  StyleEngineHost::globalStyleEngine()->unloadStyles();
+}
+
+QUrl StyleEngineSetup::styleSheetSource() const
+{
+  return mStyleSheetSourceUrl.url();
+}
+
+void StyleEngineSetup::setStyleSheetSource(const QUrl& url)
+{
+  if (mStyleSheetSourceUrl.url() != url) {
+    mStyleSheetSourceUrl.set(url, this, mFsWatcher);
+
+    StyleEngineHost::globalStyleEngine()->setStyleSheetSource(url);
+
+    Q_EMIT styleSheetSourceChanged(url);
+  }
+}
+
+QUrl StyleEngineSetup::defaultStyleSheetSource() const
+{
+  return mDefaultStyleSheetSourceUrl.url();
+}
+
+void StyleEngineSetup::setDefaultStyleSheetSource(const QUrl& url)
+{
+  if (mDefaultStyleSheetSourceUrl.url() != url) {
+    mDefaultStyleSheetSourceUrl.set(url, this, mFsWatcher);
+
+    StyleEngineHost::globalStyleEngine()->setDefaultStyleSheetSource(url);
+
+    Q_EMIT defaultStyleSheetSourceChanged(url);
+  }
+}
+
+QUrl StyleEngineSetup::stylePath() const
+{
+  return mStylePathUrl;
+}
+
+void StyleEngineSetup::setStylePath(const QUrl& url)
+{
+  mStylesDir.setStylePath(url);
+
+  if (mStylePathUrl != url) {
+    mStylePathUrl = url;
+
+    mStylePath = qmlEngine(this)->baseUrl().resolved(mStylePathUrl).toLocalFile();
+
+    updateSourceUrls();
+  }
+}
+
+QString StyleEngineSetup::styleName() const
+{
+  return mStyleSheetSourceUrl.url().fileName();
+}
+
+void StyleEngineSetup::setStyleName(const QString& styleName)
+{
+  if (mStyleName != styleName) {
+    mStyleName = styleName;
+
+    updateSourceUrls();
+
+    Q_EMIT styleNameChanged();
+  }
+}
+
+QString StyleEngineSetup::defaultStyleName() const
+{
+  return mDefaultStyleSheetSourceUrl.url().fileName();
+}
+
+void StyleEngineSetup::setDefaultStyleName(const QString& styleName)
+{
+  if (mDefaultStyleName != styleName) {
+    mDefaultStyleName = styleName;
+
+    updateSourceUrls();
+
+    Q_EMIT defaultStyleNameChanged();
+  }
+}
+
+void StyleEngineSetup::updateSourceUrls()
+{
+  if (!mStylePath.isEmpty()) {
+    QDir styleDir(mStylePath);
+
+    if (!mStyleName.isEmpty() && styleDir.exists(mStyleName)) {
+      setStyleSheetSource(QUrl::fromLocalFile(styleDir.absoluteFilePath(mStyleName)));
+    }
+
+    if (!mDefaultStyleName.isEmpty() && styleDir.exists(mDefaultStyleName)) {
+      setDefaultStyleSheetSource(
+        QUrl::fromLocalFile(styleDir.absoluteFilePath(mDefaultStyleName)));
+    }
+  }
+}
+
+QVariantList StyleEngineSetup::fileExtensions() const
+{
+  return mStylesDir.fileExtensions();
+}
+
+void StyleEngineSetup::setFileExtensions(const QVariantList& exts)
+{
+  mStylesDir.setFileExtensions(exts);
+}
+
+QVariantList StyleEngineSetup::availableStyles()
+{
+  return mStylesDir.availableStyleSheetNames();
+}
+
+void StyleEngineSetup::onFileChanged(const QString&)
+{
+  StyleEngineHost::globalStyleEngine()->loadStyles();
+}
+
+void StyleEngineSetup::classBegin()
+{
+  StyleEngineHost::globalStyleEngine()->bindToQmlEngine(*qmlEngine(parent()));
+}
+
+void StyleEngineSetup::componentComplete()
+{
+}
+
+void StyleEngineSetup::SourceUrl::set(const QUrl& url,
+                                      StyleEngineSetup* pParent,
+                                      QFileSystemWatcher& watcher)
+{
+  if (mSourceUrl.isLocalFile()) {
+    auto stylePath = qmlEngine(pParent)->baseUrl().resolved(mSourceUrl).toLocalFile();
+    if (!stylePath.isEmpty() && QFile(stylePath).exists()) {
+      watcher.removePath(stylePath);
+    }
+  }
+
+  mSourceUrl = url;
+
+  if (mSourceUrl.isLocalFile()) {
+    auto stylePath = qmlEngine(pParent)->baseUrl().resolved(mSourceUrl).toLocalFile();
+    if (!stylePath.isEmpty() && QFile(stylePath).exists()) {
+      watcher.addPath(stylePath);
+    }
+  }
+}
+
+} // namespace stylesheets
+} // namespace aqt

--- a/src/StyleEngineSetup.cpp
+++ b/src/StyleEngineSetup.cpp
@@ -50,7 +50,7 @@ StyleEngineSetup::StyleEngineSetup(QObject* pParent)
   connect(&mStylesDir, &StylesDirWatcher::fileExtensionsChanged, this,
           &StyleEngineSetup::fileExtensionsChanged);
 
-  auto* pEngine = StyleEngineHost::globalStyleEngine();
+  auto* pEngine = &StyleEngine::instance();
 
   connect(pEngine, &StyleEngine::styleChanged, this, &StyleEngineSetup::styleChanged);
   connect(pEngine, &StyleEngine::exception, this, &StyleEngineSetup::exception);
@@ -58,7 +58,7 @@ StyleEngineSetup::StyleEngineSetup(QObject* pParent)
 
 StyleEngineSetup::~StyleEngineSetup()
 {
-  StyleEngineHost::globalStyleEngine()->unloadStyles();
+  StyleEngine::instance().unloadStyles();
 }
 
 QUrl StyleEngineSetup::styleSheetSource() const
@@ -71,7 +71,7 @@ void StyleEngineSetup::setStyleSheetSource(const QUrl& url)
   if (mStyleSheetSourceUrl.url() != url) {
     mStyleSheetSourceUrl.set(url, this, mFsWatcher);
 
-    StyleEngineHost::globalStyleEngine()->setStyleSheetSource(url);
+    StyleEngine::instance().setStyleSheetSource(url);
 
     Q_EMIT styleSheetSourceChanged(url);
   }
@@ -87,7 +87,7 @@ void StyleEngineSetup::setDefaultStyleSheetSource(const QUrl& url)
   if (mDefaultStyleSheetSourceUrl.url() != url) {
     mDefaultStyleSheetSourceUrl.set(url, this, mFsWatcher);
 
-    StyleEngineHost::globalStyleEngine()->setDefaultStyleSheetSource(url);
+    StyleEngine::instance().setDefaultStyleSheetSource(url);
 
     Q_EMIT defaultStyleSheetSourceChanged(url);
   }
@@ -176,12 +176,12 @@ QVariantList StyleEngineSetup::availableStyles()
 
 void StyleEngineSetup::onFileChanged(const QString&)
 {
-  StyleEngineHost::globalStyleEngine()->loadStyles();
+  StyleEngine::instance().loadStyles();
 }
 
 void StyleEngineSetup::classBegin()
 {
-  StyleEngineHost::globalStyleEngine()->bindToQmlEngine(*qmlEngine(parent()));
+  StyleEngine::instance().bindToQmlEngine(*qmlEngine(parent()));
 }
 
 void StyleEngineSetup::componentComplete()

--- a/src/StyleEngineSetup.hpp
+++ b/src/StyleEngineSetup.hpp
@@ -1,0 +1,283 @@
+/*
+Copyright (c) 2014-2015 Ableton AG, Berlin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include "StylesDirWatcher.hpp"
+#include "Warnings.hpp"
+
+SUPPRESS_WARNINGS
+#include <QtCore/QFileSystemWatcher>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QUrl>
+#include <QtCore/QVariantList>
+#include <QtQml/QQmlParserStatus>
+RESTORE_WARNINGS
+
+namespace aqt
+{
+namespace stylesheets
+{
+
+/*! Interface to the singleton StyleEngine
+ *
+ * Setup the style engine for the application.  There should be a single instance of this
+ * class for a complete application only.  All following instances would overwrite the
+ * previous settings and the first instance being destroyed invalidates the style
+ * engine.
+ *
+ * The style engine supports up to two stylesheets specified by the
+ * styleSheetSource and defaultStyleSheetSource properties.  Rules from the
+ * former take precedence of the those from the later.
+ *
+ * @par Example
+ * @code
+ * ApplicationWindow {
+ *   StyleEngine {
+ *     styleSheetSource: "../Assets/bright.css"
+ *     defaultStyleSheetSource: "Resources/default.css"
+ *   }
+ * }
+ * @endcode
+ *
+ * @par Import in QML:
+ * <pre>
+ * import Aqt.StyleSheets 1.2
+ * </pre>
+ * @since 1.0
+ */
+class StyleEngineSetup : public QObject, public QQmlParserStatus
+{
+  Q_OBJECT
+  Q_DISABLE_COPY(StyleEngineSetup)
+  Q_INTERFACES(QQmlParserStatus)
+
+  /*! @public Contains the URL of folder containing style sheets
+   *
+   * The URL is resolved relative to the location of the QML file in which the
+   * StyleEngine is instantiated.  It must resolve to a local file path.  The
+   * StyleEngine is actively watching this folder.  Appearing or disappearing
+   * style sheet file will fire availableStylesChanged() signals.
+   *
+   * @deprecated Use styleSheetSource and defaultStyleSheetSource properties
+   * instead.  For watching folders of style sheets use StylesDirWatcher.
+   */
+  Q_PROPERTY(QUrl stylePath READ stylePath WRITE setStylePath)
+
+  /*! @public Contains the file name of the current style sheet
+   *
+   * The style sheet file is actively watched and, if changing, reloaded.  New
+   * or changing properties will fire styleChanged(int) signals.  There's no
+   * need though to actively monitor this signal since properties requested
+   * via the StyleSet attached type will automatically connect to the style
+   * engine.
+   *
+   * The style sheet file name can be set during app runtime.  This will load
+   * the new style sheet and update all StyleSet.props in the app accordingly.
+   *
+   * @see styleName property
+   *
+   * @deprecated Use styleSheetSource property instead.
+   */
+  Q_PROPERTY(QString styleName READ styleName WRITE setStyleName NOTIFY styleNameChanged)
+
+  /*! @public Contains the file name of the default style sheet
+   *
+   * @see styleName property
+   *
+   * @deprecated Use defaultStyleSheetSource property instead.
+   */
+  Q_PROPERTY(QString defaultStyleName READ defaultStyleName WRITE setDefaultStyleName
+               NOTIFY defaultStyleNameChanged)
+
+  /*! @public Defines the list of support file extensions
+   *
+   * Only files with these extensions will be found as style sheets.  Default
+   * is *.css only.
+   *
+   * @deprecated Use StylesDirWatcher instead.
+   */
+  Q_PROPERTY(QVariantList fileExtensions READ fileExtensions WRITE setFileExtensions
+               NOTIFY fileExtensionsChanged)
+
+  /*! @public Contains the list of all style sheet files found in the
+   * stylePath folder
+   *
+   * Contains all files in the folder given by the stylePath property.
+   * Only files ending in the @c *.css extension are listed.
+   *
+   * Whenever the list of style sheet files in the watch folder (given by the
+   * stylePath property) is changed the availableStylesChanged() signal will
+   * be fired.
+   *
+   * The most like usage of this property is to build a style sheet chooser
+   * (@ref StyleSheetMenu).
+   *
+   * @deprecated Use StylesDirWatcher instead.
+   */
+  Q_PROPERTY(QVariantList availableStyles READ availableStyles NOTIFY
+               availableStylesChanged)
+
+  /*! @public Contains the source url of the current style sheet
+   *
+   * The style sheet file is actively watched and, if changing, reloaded.  New
+   * or changing properties will fire styleChanged(int) signals.  There's no
+   * need though to actively monitor this signal since properties requested
+   * via the StyleSet attached type will automatically connect to the style
+   * engine.
+   *
+   * The style sheet url can be set during app runtime.  This will load the
+   * new style sheet and update all StyleSet.props in the app accordingly.
+   *
+   * The URL is resolved relative to the location of the QML file in which the
+   * StyleEngine is instantiated.
+   *
+   * @since 1.1
+   */
+  Q_PROPERTY(QUrl styleSheetSource READ styleSheetSource WRITE setStyleSheetSource NOTIFY
+               styleSheetSourceChanged REVISION 1)
+
+  /*! @public Contains the source url of the default style sheet
+   *
+   * @see styleSheetSource property
+   *
+   * @since 1.1
+   */
+  Q_PROPERTY(QUrl defaultStyleSheetSource READ defaultStyleSheetSource WRITE
+               setDefaultStyleSheetSource NOTIFY defaultStyleSheetSourceChanged
+                 REVISION 1)
+
+public:
+  /*! @cond DOXYGEN_IGNORE */
+  explicit StyleEngineSetup(QObject* pParent = nullptr);
+  ~StyleEngineSetup();
+
+  QUrl styleSheetSource() const;
+  void setStyleSheetSource(const QUrl& url);
+
+  QUrl defaultStyleSheetSource() const;
+  void setDefaultStyleSheetSource(const QUrl& url);
+
+  /*! @deprecated Use StylesDirWatcher instead. */
+  QUrl stylePath() const;
+  /*! @deprecated Use StylesDirWatcher instead. */
+  void setStylePath(const QUrl& path);
+
+  /*! @deprecated Use styleSheetSource instead. */
+  QString styleName() const;
+  /*! @deprecated Use setStyleSheetSource instead. */
+  void setStyleName(const QString& styleName);
+
+  /*! @deprecated Use defaultStyleSheetSource instead. */
+  QString defaultStyleName() const;
+  /*! @deprecated Use setDefaultStyleSheetSource instead. */
+  void setDefaultStyleName(const QString& styleName);
+
+  /*! @deprecated Use StylesDirWatcher instead */
+  QVariantList fileExtensions() const;
+  /*! @deprecated Use StylesDirWatcher instead */
+  void setFileExtensions(const QVariantList& exts);
+
+  /*! returns a list of URL with available style files
+   *
+   * @deprecated Use StylesDirWatcher instead */
+  QVariantList availableStyles();
+
+  virtual void classBegin();
+  virtual void componentComplete();
+/*! @endcond */
+
+Q_SIGNALS:
+  /*! Fires when the style sheet is replaced or changed on the disk */
+  void styleChanged();
+  /*! Fires when a new style sheet file name is set to the styleName property */
+  void styleNameChanged();
+  /*! Fires when a new default style sheet file name is set to the styleName
+   * property */
+  void defaultStyleNameChanged();
+  /*! Fires when a new set of file extensions are set to the fileExtensions
+   * property */
+  void fileExtensionsChanged();
+  /*! Fires when the list of style sheets in the stylePath folder changes */
+  void availableStylesChanged();
+
+  /*! Emitted when the style sheet source URL changes.
+   *
+   * @since 1.1
+   */
+  Q_REVISION(1) void styleSheetSourceChanged(const QUrl& url);
+  /*! Emitted when the default style sheet source URL changes.
+   *
+   * @since 1.1
+   */
+  Q_REVISION(1) void defaultStyleSheetSourceChanged(const QUrl& url);
+
+  /*! Emitted when any part of the style sheet subsystem has to report some
+   *  exceptional situation
+   *
+   * @param type Indicates a type of exception, like "font-not-found", etc.
+   * @param message Some descriptive message
+   *
+   * @since 1.1
+   */
+  Q_REVISION(1) void exception(const QString& type, const QString& message);
+
+private Q_SLOTS:
+  void onFileChanged(const QString& path);
+
+private:
+  class SourceUrl
+  {
+  public:
+    void set(const QUrl& url, StyleEngineSetup* pParent, QFileSystemWatcher& watcher);
+
+    QUrl url() const
+    {
+      return mSourceUrl;
+    }
+
+    bool isEmpty() const
+    {
+      return mSourceUrl.isEmpty();
+    }
+
+    QUrl mSourceUrl;
+  };
+
+  void updateSourceUrls();
+
+private:
+  QUrl mStylePathUrl;        //!< @deprecated
+  QString mStylePath;        //!< @deprecated
+  QString mStyleName;        //!< @deprecated
+  QString mDefaultStyleName; //!< @deprecated
+
+  SourceUrl mStyleSheetSourceUrl;
+  SourceUrl mDefaultStyleSheetSourceUrl;
+
+  QFileSystemWatcher mFsWatcher;
+  StylesDirWatcher mStylesDir;
+};
+
+} // namespace stylesheets
+} // namespace aqt

--- a/src/StyleMatchTree.cpp
+++ b/src/StyleMatchTree.cpp
@@ -591,26 +591,34 @@ void dumpMatchResults(const MatchResult& result, std::ostream& stream = std::cou
 
 std::string describeMatchedPath(const IStyleMatchTree* itree, const UiItemPath& path)
 {
-  const StyleMatchTree& tree = *static_cast<const StyleMatchTree*>(itree);
+  if (itree) {
+    const StyleMatchTree& tree = *static_cast<const StyleMatchTree*>(itree);
 
-  MatchResult result = findMatchingRules(tree, path);
-  sortMatchResults(result);
-  std::reverse(result.begin(), result.end());
+    MatchResult result = findMatchingRules(tree, path);
+    sortMatchResults(result);
+    std::reverse(result.begin(), result.end());
 
-  std::ostringstream stream;
-  stream << "Style info for path " << path << std::endl;
-  dumpMatchResults(result, stream);
+    std::ostringstream stream;
+    stream << "Style info for path " << path << std::endl;
+    dumpMatchResults(result, stream);
 
-  return stream.str();
+    return stream.str();
+  }
+
+  return {};
 }
 
 PropertyMap matchPath(const IStyleMatchTree* itree, const UiItemPath& path)
 {
-  const StyleMatchTree& tree = *static_cast<const StyleMatchTree*>(itree);
+  if (itree) {
+    const StyleMatchTree& tree = *static_cast<const StyleMatchTree*>(itree);
 
-  MatchResult result = findMatchingRules(tree, path);
-  sortMatchResults(result);
-  return mergeMatchResults(result);
+    MatchResult result = findMatchingRules(tree, path);
+    sortMatchResults(result);
+    return mergeMatchResults(result);
+  }
+
+  return PropertyMap{};
 }
 
 std::ostream& operator<<(std::ostream& os, const UiItemPath& path)

--- a/src/StylePlugin.cpp
+++ b/src/StylePlugin.cpp
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #include "StylePlugin.hpp"
 
-#include "StyleEngine.hpp"
+#include "StyleEngineSetup.hpp"
 #include "StylesDirWatcher.hpp"
 #include "StyleSet.hpp"
 #include "StyleSetProps.hpp"
@@ -41,8 +41,8 @@ void aqt::stylesheets::StylePlugin::registerTypes(const char* pUri)
     pUri, 1, 0, "StyleSetProps", "Exposed as StyleSet.props");
   qmlRegisterUncreatableType<aqt::stylesheets::StyleSetProps, 2>(
     pUri, 1, 2, "StyleSetProps", "Exposed as StyleSet.props");
-  qmlRegisterType<aqt::stylesheets::StyleEngine>(pUri, 1, 0, "StyleEngine");
-  qmlRegisterType<aqt::stylesheets::StyleEngine, 1>(pUri, 1, 1, "StyleEngine");
+  qmlRegisterType<aqt::stylesheets::StyleEngineSetup>(pUri, 1, 0, "StyleEngine");
+  qmlRegisterType<aqt::stylesheets::StyleEngineSetup, 1>(pUri, 1, 1, "StyleEngine");
   qmlRegisterType<aqt::stylesheets::StylesDirWatcher>(pUri, 1, 1, "StylesDirWatcher");
 }
 

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -184,8 +184,6 @@ void StyleSet::setupStyle()
     mpStyleSetProps = pEngine->styleSetProps(mPath);
 
     connect(mpStyleSetProps, &StyleSetProps::propsChanged, this, &StyleSet::propsChanged);
-    connect(
-      mpStyleSetProps, &StyleSetProps::invalidated, this, &StyleSet::onPropsInvalidated);
 
     Q_EMIT propsChanged();
   }
@@ -239,13 +237,6 @@ void StyleSet::onParentChanged(QQuickItem* pNewParent)
 
     Q_EMIT pathChanged();
   }
-}
-
-void StyleSet::onPropsInvalidated()
-{
-  mpStyleSetProps->disconnect(this);
-  mpStyleSetProps = StyleSetProps::nullStyleSetProps();
-  Q_EMIT propsChanged();
 }
 
 } // namespace stylesheets

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -151,12 +151,6 @@ StyleSet::StyleSet(QObject* pParent)
     }
 
     mPath = traversePathUp(p);
-
-    if (!pEngine) {
-      connect(StyleEngineHost::globalStyleEngineHost(),
-              &StyleEngineHost::styleEngineLoaded, this, &StyleSet::onStyleEngineLoaded);
-    }
-
     setupStyle();
   }
 }
@@ -164,18 +158,6 @@ StyleSet::StyleSet(QObject* pParent)
 StyleSet* StyleSet::qmlAttachedProperties(QObject* pObject)
 {
   return new StyleSet(pObject);
-}
-
-void StyleSet::onStyleEngineLoaded(StyleEngine* pEngine)
-{
-  Q_ASSERT(pEngine);
-  Q_UNUSED(pEngine);
-
-  disconnect(StyleEngineHost::globalStyleEngineHost(),
-             &StyleEngineHost::styleEngineLoaded, this, &StyleSet::onStyleEngineLoaded);
-
-  setupStyle();
-  Q_ASSERT(mpStyleSetProps != StyleSetProps::nullStyleSetProps());
 }
 
 void StyleSet::setupStyle()

--- a/src/StyleSet.cpp
+++ b/src/StyleSet.cpp
@@ -129,7 +129,7 @@ UiItemPath traversePathUp(QObject* pObj)
 
 StyleSet::StyleSet(QObject* pParent)
   : QObject(pParent)
-  , mpStyleSetProps(StyleSetProps::nullStyleSetProps())
+  , mpStyleSetProps(nullptr)
 {
   QObject* p = parent();
   if (p) {

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -203,7 +203,6 @@ Q_SIGNALS:
 private Q_SLOTS:
   void onStyleEngineLoaded(StyleEngine* pEngine);
   void onParentChanged(QQuickItem* pNewParent);
-  void onPropsInvalidated();
 
 private:
   void setupStyle();

--- a/src/StyleSet.hpp
+++ b/src/StyleSet.hpp
@@ -201,7 +201,6 @@ Q_SIGNALS:
   /*! @cond DOXYGEN_IGNORE */
 
 private Q_SLOTS:
-  void onStyleEngineLoaded(StyleEngine* pEngine);
   void onParentChanged(QQuickItem* pNewParent);
 
 private:

--- a/src/StyleSetProps.cpp
+++ b/src/StyleSetProps.cpp
@@ -75,7 +75,7 @@ bool StyleSetProps::getImpl(Property& prop, const QString& key) const
     return true;
   }
 
-  if (mpEngine) {
+  if (mpEngine->hasStylesLoaded()) {
     styleSheetsLogWarning() << "Property " << key.toStdString() << " not found ("
                             << pathToString(mPath) << ")";
     Q_EMIT mpEngine->exception(QString::fromLatin1("propertyNotFound"),
@@ -173,7 +173,7 @@ void StyleSetProps::loadProperties()
 
 void StyleSetProps::invalidate()
 {
-  Q_EMIT invalidated();
+  mpProperties = nullProperties();
 }
 
 } // namespace stylesheets

--- a/src/StyleSetProps.cpp
+++ b/src/StyleSetProps.cpp
@@ -171,5 +171,10 @@ void StyleSetProps::loadProperties()
   }
 }
 
+void StyleSetProps::invalidate()
+{
+  Q_EMIT invalidated();
+}
+
 } // namespace stylesheets
 } // namespace aqt

--- a/src/StyleSetProps.cpp
+++ b/src/StyleSetProps.cpp
@@ -43,9 +43,8 @@ PropertyMap* nullProperties()
 
 } // anon namespace
 
-StyleSetProps::StyleSetProps(const UiItemPath& path, StyleEngine* pEngine)
-  : mpEngine(pEngine)
-  , mPath(path)
+StyleSetProps::StyleSetProps(const UiItemPath& path)
+  : mPath(path)
   , mpProperties(nullProperties())
 {
   loadProperties();
@@ -53,7 +52,7 @@ StyleSetProps::StyleSetProps(const UiItemPath& path, StyleEngine* pEngine)
 
 StyleSetProps* StyleSetProps::nullStyleSetProps()
 {
-  static StyleSetProps sNullStyleSetProps{{}, nullptr};
+  static StyleSetProps sNullStyleSetProps{{}};
   return &sNullStyleSetProps;
 }
 
@@ -75,12 +74,14 @@ bool StyleSetProps::getImpl(Property& prop, const QString& key) const
     return true;
   }
 
-  if (mpEngine->hasStylesLoaded()) {
+  auto& engine = StyleEngine::instance();
+
+  if (engine.hasStylesLoaded()) {
     styleSheetsLogWarning() << "Property " << key.toStdString() << " not found ("
                             << pathToString(mPath) << ")";
-    Q_EMIT mpEngine->exception(QString::fromLatin1("propertyNotFound"),
-                               QString::fromLatin1("Property '%1' not found (%2)")
-                                 .arg(key, QString::fromStdString(pathToString(mPath))));
+    Q_EMIT engine.exception(QString::fromLatin1("propertyNotFound"),
+                            QString::fromLatin1("Property '%1' not found (%2)")
+                              .arg(key, QString::fromStdString(pathToString(mPath))));
   }
 
   return false;
@@ -153,22 +154,17 @@ QUrl StyleSetProps::url(const QString& key) const
   Property prop;
   auto url = lookupProperty<QUrl>(prop, key);
 
-  if (mpEngine) {
-    auto baseUrl = prop.mSourceLoc.mSourceLayer == 0 ? mpEngine->defaultStyleSheetSource()
-                                                     : mpEngine->styleSheetSource();
-    return mpEngine->resolveResourceUrl(baseUrl, url);
-  }
+  auto& engine = StyleEngine::instance();
 
-  return url;
+  auto baseUrl = prop.mSourceLoc.mSourceLayer == 0 ? engine.defaultStyleSheetSource()
+                                                   : engine.styleSheetSource();
+  return engine.resolveResourceUrl(baseUrl, url);
 }
+
 void StyleSetProps::loadProperties()
 {
-  if (mpEngine) {
-    mpProperties = mpEngine->properties(mPath);
-    Q_EMIT propsChanged();
-  } else {
-    mpProperties = nullProperties();
-  }
+  mpProperties = StyleEngine::instance().properties(mPath);
+  Q_EMIT propsChanged();
 }
 
 void StyleSetProps::invalidate()

--- a/src/StyleSetProps.cpp
+++ b/src/StyleSetProps.cpp
@@ -50,12 +50,6 @@ StyleSetProps::StyleSetProps(const UiItemPath& path)
   loadProperties();
 }
 
-StyleSetProps* StyleSetProps::nullStyleSetProps()
-{
-  static StyleSetProps sNullStyleSetProps{{}};
-  return &sNullStyleSetProps;
-}
-
 bool StyleSetProps::isValid() const
 {
   return !mpProperties->empty();

--- a/src/StyleSetProps.hpp
+++ b/src/StyleSetProps.hpp
@@ -269,6 +269,8 @@ public:
   /*! @cond DOXYGEN_IGNORE */
   void loadProperties();
 
+  void invalidate();
+
 Q_SIGNALS:
   void propsChanged();
   void invalidated();

--- a/src/StyleSetProps.hpp
+++ b/src/StyleSetProps.hpp
@@ -49,8 +49,6 @@ class StyleSetProps : public QObject
 public:
   /*! @cond DOXYGEN_IGNORE */
   explicit StyleSetProps(const UiItemPath& path);
-
-  static StyleSetProps* nullStyleSetProps();
   /*! @endcond */
 
   /*! Indicates whether this style set has any properties set */

--- a/src/StyleSetProps.hpp
+++ b/src/StyleSetProps.hpp
@@ -273,7 +273,6 @@ public:
 
 Q_SIGNALS:
   void propsChanged();
-  void invalidated();
 
 private:
   bool getImpl(Property& def, const QString& key) const;

--- a/src/StyleSetProps.hpp
+++ b/src/StyleSetProps.hpp
@@ -39,7 +39,6 @@ namespace aqt
 namespace stylesheets
 {
 
-class StyleEngine;
 class StyleSet;
 
 /*! Provides style properties to QML via StyleSet */
@@ -49,7 +48,7 @@ class StyleSetProps : public QObject
 
 public:
   /*! @cond DOXYGEN_IGNORE */
-  StyleSetProps(const UiItemPath& path, StyleEngine* pEngine);
+  explicit StyleSetProps(const UiItemPath& path);
 
   static StyleSetProps* nullStyleSetProps();
   /*! @endcond */
@@ -283,7 +282,6 @@ private:
   T lookupProperty(Property& def, const QString& key) const;
 
 private:
-  StyleEngine* const mpEngine;
   UiItemPath mPath;
   PropertyMap* mpProperties;
   /*! @endcond */


### PR DESCRIPTION
This PR simplifies the code and the initialization/destruction phases by making the StyleEngine a singleton with a dedicated type to configure it from QML.

@gck-ableton, @mak-ableton: Please review! Thanks!