### PR TITLE
Let's StyleSetPropsRef track their StyleSetProps by weak ptr

### DIFF
--- a/src/StyleEngine.cpp
+++ b/src/StyleEngine.cpp
@@ -256,9 +256,9 @@ StyleSetPropsRef StyleEngine::styleSetProps(const UiItemPath& path)
 
   if (iElement == mStyleSetPropsRefs.end()) {
     mStyleSetPropsInstances.emplace_back(
-      estd::make_unique<UsageCountedStyleSetProps>(path));
+      std::make_shared<UsageCountedStyleSetProps>(path));
 
-    auto pStyleSetProps = mStyleSetPropsInstances.back().get();
+    auto pStyleSetProps = mStyleSetPropsInstances.back();
     std::tie(iElement, std::ignore) =
       mStyleSetPropsRefs.emplace(path, StyleSetPropsRef{pStyleSetProps});
   }

--- a/src/StyleEngine.hpp
+++ b/src/StyleEngine.hpp
@@ -142,7 +142,7 @@ private:
   void notifyMissingProperties();
 
 private:
-  using StyleSetPropsInstances = std::vector<std::unique_ptr<UsageCountedStyleSetProps>>;
+  using StyleSetPropsInstances = std::vector<std::shared_ptr<UsageCountedStyleSetProps>>;
   using StyleSetPropsRefs =
     std::unordered_map<UiItemPath, StyleSetPropsRef, UiItemPathHasher>;
 

--- a/src/StyleSetProps.cpp
+++ b/src/StyleSetProps.cpp
@@ -182,26 +182,26 @@ StyleSetPropsRef::StyleSetPropsRef()
 {
 }
 
-StyleSetPropsRef::StyleSetPropsRef(UsageCountedStyleSetProps* pUsageCountedStyleSetProps)
+StyleSetPropsRef::StyleSetPropsRef(const std::shared_ptr<UsageCountedStyleSetProps>& pUsageCountedStyleSetProps)
   : mpUsageCountedStyleSetProps{pUsageCountedStyleSetProps}
 {
-  if (mpUsageCountedStyleSetProps) {
-    ++mpUsageCountedStyleSetProps->usageCount;
+  if (auto pStyleSetProps = mpUsageCountedStyleSetProps.lock()) {
+    ++pStyleSetProps->usageCount;
   }
 }
 
 StyleSetPropsRef::~StyleSetPropsRef()
 {
-  if (mpUsageCountedStyleSetProps) {
-    --mpUsageCountedStyleSetProps->usageCount;
+  if (auto pStyleSetProps = mpUsageCountedStyleSetProps.lock()) {
+    --pStyleSetProps->usageCount;
   }
 }
 
 StyleSetPropsRef::StyleSetPropsRef(const StyleSetPropsRef& other)
   : mpUsageCountedStyleSetProps{other.mpUsageCountedStyleSetProps}
 {
-  if (mpUsageCountedStyleSetProps) {
-    ++mpUsageCountedStyleSetProps->usageCount;
+  if (auto pStyleSetProps = mpUsageCountedStyleSetProps.lock()) {
+    ++pStyleSetProps->usageCount;
   }
 }
 
@@ -213,13 +213,18 @@ StyleSetPropsRef& StyleSetPropsRef::operator=(StyleSetPropsRef other)
 
 size_t StyleSetPropsRef::usageCount() const
 {
-  return mpUsageCountedStyleSetProps ? mpUsageCountedStyleSetProps->usageCount : 0;
+  if (auto pStyleSetProps = mpUsageCountedStyleSetProps.lock()) {
+    return pStyleSetProps->usageCount;
+  }
+  return 0;
 }
 
 StyleSetProps* StyleSetPropsRef::get()
 {
-  return mpUsageCountedStyleSetProps ? &mpUsageCountedStyleSetProps->styleSetProps
-                                     : nullptr;
+  if (auto pStyleSetProps = mpUsageCountedStyleSetProps.lock()) {
+    return &pStyleSetProps->styleSetProps;
+  }
+  return nullptr;
 }
 
 void swap(StyleSetPropsRef& a, StyleSetPropsRef& b)

--- a/src/StyleSetProps.hpp
+++ b/src/StyleSetProps.hpp
@@ -317,7 +317,7 @@ class StyleSetPropsRef
 public:
   /*! @cond DOXYGEN_IGNORE */
   StyleSetPropsRef();
-  explicit StyleSetPropsRef(UsageCountedStyleSetProps* pUsageCountedStyleSetProps);
+  explicit StyleSetPropsRef(const std::shared_ptr<UsageCountedStyleSetProps>& pUsageCountedStyleSetProps);
   ~StyleSetPropsRef();
 
   StyleSetPropsRef(const StyleSetPropsRef& other);
@@ -331,7 +331,7 @@ public:
   friend void swap(StyleSetPropsRef& a, StyleSetPropsRef& b);
 
 private:
-  UsageCountedStyleSetProps* mpUsageCountedStyleSetProps;
+  std::weak_ptr<UsageCountedStyleSetProps> mpUsageCountedStyleSetProps;
   /*! @endcond */
 };
 


### PR DESCRIPTION
There are use cases where StyleSets might live longer than the QML Engine
which created them (e.g. with deferred delete events).  In that case
destroying them must be access the StyleSetProps already destroyed by
the engine of course.

@mli-ableton 