### PR TITLE
Fix or silence -Wdouble-promotion

### DIFF
--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -136,7 +136,7 @@ QFont::HintingPreference takeFontHintingFromTokenList(QStringList& tokens)
 
 struct FontSize {
   int pixelSize = 0;
-  qreal pointSize = 0.0f;
+  qreal pointSize = 0.0;
 };
 
 /**
@@ -218,24 +218,24 @@ int transformAlphaFromFloatRatio(const std::string& arg)
   return boost::algorithm::clamp(int(std::round(256 * factor)), 0, 255);
 }
 
-float hslHue(const std::string& arg)
+double hslHue(const std::string& arg)
 {
-  return boost::algorithm::clamp(boost::lexical_cast<int>(arg) / 360.0f, 0.0f, 1.0f);
+  return boost::algorithm::clamp(boost::lexical_cast<int>(arg) / 360.0, 0.0, 1.0);
 }
 
-float percentageToFactor(const std::string& arg)
+double percentageToFactor(const std::string& arg)
 {
   if (!arg.empty() && arg.back() == '%') {
     return boost::algorithm::clamp(
-      boost::lexical_cast<int>(arg.substr(0, arg.size() - 1)) / 100.0f, 0.0f, 1.0f);
+      boost::lexical_cast<int>(arg.substr(0, arg.size() - 1)) / 100.0, 0.0, 1.0);
   }
 
   throw boost::bad_lexical_cast();
 }
 
-float factorFromFloat(const std::string& arg)
+double factorFromFloat(const std::string& arg)
 {
-  return boost::algorithm::clamp(boost::lexical_cast<float>(arg), 0.0f, 1.0f);
+  return boost::algorithm::clamp(boost::lexical_cast<double>(arg), 0.0, 1.0);
 }
 
 ExprValue makeRgbaColor(const std::vector<std::string>& args)
@@ -291,7 +291,7 @@ ExprValue makeHslColor(const std::vector<std::string>& args)
     try {
       QColor color;
       color.setHslF(
-        hslHue(args[0]), percentageToFactor(args[1]), percentageToFactor(args[2]), 1.0f);
+        hslHue(args[0]), percentageToFactor(args[1]), percentageToFactor(args[2]), 1.0);
       return color;
     } catch (const boost::bad_lexical_cast&) {
       styleSheetsLogWarning() << kHslColorExpr << "() expression with bad values";
@@ -325,7 +325,7 @@ ExprValue makeHsbColor(const std::vector<std::string>& args)
     try {
       QColor color;
       color.setHsvF(
-        hslHue(args[0]), percentageToFactor(args[1]), percentageToFactor(args[2]), 1.0f);
+        hslHue(args[0]), percentageToFactor(args[1]), percentageToFactor(args[2]), 1.0);
       return color;
     } catch (const boost::bad_lexical_cast&) {
       styleSheetsLogWarning() << kHslColorExpr << "() expression with bad values";

--- a/src/Warnings.hpp
+++ b/src/Warnings.hpp
@@ -26,13 +26,18 @@ THE SOFTWARE.
 
 #if defined(__clang__)
 
+  #if __has_warning("-Wdouble-promotion")
+    #define ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_DOUBLE_PROMOTION \
+    _Pragma("clang diagnostic ignored \"-Wdouble-promotion\"")
+  #else
+    #define ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_DOUBLE_PROMOTION
+  #endif
   #if __has_warning("-Wreserved-id-macro")
     #define ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_RESERVED_ID_MACRO \
     _Pragma("clang diagnostic ignored \"-Wreserved-id-macro\"")
   #else
     #define ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_RESERVED_ID_MACRO
   #endif
-
   #if __has_warning("-Wunused-local-typedef")
     #define ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_UNUSED_LOCAL_TYPEDEF \
     _Pragma("clang diagnostic ignored \"-Wunused-local-typedef\"")
@@ -70,6 +75,7 @@ THE SOFTWARE.
     _Pragma("clang diagnostic ignored \"-Wunused-parameter\"") \
     _Pragma("clang diagnostic ignored \"-Wused-but-marked-unused\"") \
     _Pragma("clang diagnostic ignored \"-Wweak-vtables\"") \
+    ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_DOUBLE_PROMOTION \
     ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_RESERVED_ID_MACRO \
     ABL_PRAGMA_CLANG_DIAGNOSTIC_IGNORED_UNUSED_LOCAL_TYPEDEF
 

--- a/src/test/tst_StyleMatchTree.cpp
+++ b/src/test/tst_StyleMatchTree.cpp
@@ -604,8 +604,8 @@ TEST(StyleMatchTreeTest, hslColors)
 
   EXPECT_EQ(1, pm.size());
   EXPECT_EQ(120, propertyAsColor(pm, "color").hslHue());
-  EXPECT_NEAR(1.0f, propertyAsColor(pm, "color").hslSaturationF(), 0.00001f);
-  EXPECT_NEAR(0.5f, propertyAsColor(pm, "color").lightnessF(), 0.00001f);
+  EXPECT_NEAR(1.0, propertyAsColor(pm, "color").hslSaturationF(), 0.00001);
+  EXPECT_NEAR(0.5, propertyAsColor(pm, "color").lightnessF(), 0.00001);
 }
 
 TEST(StyleMatchTreeTest, hslaColors)
@@ -621,7 +621,7 @@ TEST(StyleMatchTreeTest, hslaColors)
 
   EXPECT_EQ(1, pm.size());
   EXPECT_EQ(359, propertyAsColor(pm, "color").hslHue());
-  EXPECT_NEAR(0.97f, propertyAsColor(pm, "color").hslSaturationF(), 0.00001f);
-  EXPECT_NEAR(0.13f, propertyAsColor(pm, "color").lightnessF(), 0.00001f);
-  EXPECT_NEAR(0.23f, propertyAsColor(pm, "color").alphaF(), 0.00001f);
+  EXPECT_NEAR(0.97, propertyAsColor(pm, "color").hslSaturationF(), 0.00001);
+  EXPECT_NEAR(0.13, propertyAsColor(pm, "color").lightnessF(), 0.00001);
+  EXPECT_NEAR(0.23, propertyAsColor(pm, "color").alphaF(), 0.00001);
 }


### PR DESCRIPTION
-Wdouble-promotion is a new warning introduced in Xcode 7.3 that warns
against implicitly converting a float to a double.

RFC @ala-ableton 