### PR TITLE
Make qmldir static

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-qml/Aqt/StyleSheets/qmldir
-tests/Aqt/Testing/qmldir
 build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
     - cmake .. -DCMAKE_BUILD_TYPE=$CONFIGURATION
 
 script:
-    - cmake --build .
-    - ctest -V
-    - qmlscene --quit -I ../qml ../examples/TestApp.qml
+    - cmake --build . --config $CONFIGURATION
+    - cmake --build . --config $CONFIGURATION --target install
+    - ctest -V -C $CONFIGURATION
+    - qmlscene --quit -I lib/qml ../examples/TestApp.qml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL Clang
     -Wno-weak-vtables
     )
 elseif(MSVC)
-  set(warning_options /WX /W4 /wd4275 /wd4503 /wd4512 /wd4714)
+  set(warning_options /WX /W4 /wd4127 /wd4275 /wd4503 /wd4512 /wd4714)
 endif()
 
 set(CMAKE_AUTOMOC ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,15 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)
 set(CMAKE_MACOSX_RPATH ON)
 
+# We install aqt-stylesheets within the build dir. It's up to you to
+# move it elsewhere.
+#
+# You can customize PLUGIN_INSTALL_DIR to be inside the Qt
+# distribution like all the other qml plugins, if you want to install
+# it system-wide.
+
+set(PLUGIN_INSTALL_DIR "${PROJECT_BINARY_DIR}/lib/qml")
+
 enable_testing()
 
 find_package(Qt5Quick 5.3.0 REQUIRED)

--- a/README.md
+++ b/README.md
@@ -38,13 +38,16 @@ Windows:
   mkdir build
   cd build
   cmake ..
-  cmake --build .
+  cmake --build . --config Release
+  cmake --build . --config Release --target install
 ```
+
+The resulting plugin is then found inside `build/lib/qml`
 
 The unit tests can be executed with ctest:
 
 ```
-  ctest -V
+  ctest -V -C Release
 ```
 
 You might set the following variables:
@@ -69,7 +72,7 @@ In the `examples` folder there's an example app, showing how to use some of the
 feature of the StylePlugin. You can run the app with:
 
 ```
-  qmlscene -I qml/ examples/TestApp.qml
+  qmlscene -I build/lib/qml examples/TestApp.qml
 ```
 
 While qmlscene is running you can change `examples/style.css` and watch the
@@ -81,7 +84,7 @@ application update.
 In the `benchmarks` folder there are benchmarks that can be run manually with:
 
 ```
-qmltestrunner -input benchmarks/benchmark_*.qml -import qml
+qmltestrunner -import build/lib/qml -input benchmarks/benchmark_*.qml
 ```
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,8 @@ build_script:
   - mkdir build && cd build
   - cmake .. -G"%CMAKE_GENERATOR%" -DBoost_INCLUDE_DIR=%BOOST_ROOT%
   - cmake --build . --config %CONFIGURATION%
+  - cmake --build . --config %CONFIGURATION% --target install
 
 test_script:
   - ctest -C %CONFIGURATION% -V
-  - qmlscene --quit -I ../qml ../examples/TestApp.qml
+  - qmlscene --quit -I lib/qml ../examples/TestApp.qml

--- a/examples/fonts/README.md
+++ b/examples/fonts/README.md
@@ -9,8 +9,8 @@ Run this from the checkouts toplevel folder:
 
 ```
   $ cd aqt-stylesheets/
-  $ qmlscene -I qml examples/fonts/UseFonts1.0.qml
-  $ qmlscene -I qml examples/fonts/UseFonts1.1.qml
+  $ qmlscene -I build/lib/qml examples/fonts/UseFonts1.0.qml
+  $ qmlscene -I build/lib/qml examples/fonts/UseFonts1.1.qml
 ```
 
 In both cases you should see a nice big "AQT" logo on screen.

--- a/qml/Aqt/StyleSheets/qmldir
+++ b/qml/Aqt/StyleSheets/qmldir
@@ -3,4 +3,4 @@ module Aqt.StyleSheets
 StyleDebugMouseArea 1.0 StyleDebugMouseArea.qml
 StyleUtils 1.0 styleUtils.js
 
-plugin StylePlugin @PATH_TO_PLUGIN@
+plugin StylePlugin

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,32 +73,10 @@ set_target_properties(StylePlugin
 set_target_properties(StylePlugin
   PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE ${plugin_output})
 
-# rewrite qmldir to the plugin in the output folder (PATH_TO_PLUGIN is used
-# in qmldir.in)
-set(PATH_TO_PLUGIN "${PROJECT_BINARY_DIR}/output")
-configure_file(
-  "${PROJECT_SOURCE_DIR}/qml/Aqt/StyleSheets/qmldir.in"
-  "${PROJECT_SOURCE_DIR}/qml/Aqt/StyleSheets/qmldir"
-  @ONLY)
-unset(PATH_TO_PLUGIN)
-
-# prepare another qmldir, which we can use for installation
-set(PATH_TO_PLUGIN "")
-configure_file(
-  "${PROJECT_SOURCE_DIR}/qml/Aqt/StyleSheets/qmldir.in"
-  "${plugin_output}/qmldir"
-  @ONLY)
-unset(PATH_TO_PLUGIN)
-
-# TODO: Decide where to install plugins
-set(PLUGIN_INSTALL_DIR "lib/qml")
-
 install(TARGETS StylePlugin
   LIBRARY DESTINATION "${PLUGIN_INSTALL_DIR}/Aqt/StyleSheets")
-install(FILES "${plugin_output}/qmldir"
-  DESTINATION "${PLUGIN_INSTALL_DIR}/Aqt/StyleSheets")
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/qml/Aqt"
   DESTINATION "${PLUGIN_INSTALL_DIR}"
-  FILES_MATCHING REGEX ".*\\.(qml|js)$")
+  FILES_MATCHING REGEX "(qmldir|(.*\\.(qml|js)))$")
 
 add_subdirectory(test)

--- a/tests/Aqt/Testing/qmldir
+++ b/tests/Aqt/Testing/qmldir
@@ -2,4 +2,4 @@ module Aqt.Testing
 
 Utils 1.0 testUtils.js
 
-plugin AqtTestUtilsPlugin @PATH_TO_PLUGIN@
+plugin AqtTestUtilsPlugin

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,21 +42,21 @@ set_target_properties(AqtTestUtilsPlugin
 set_target_properties(AqtTestUtilsPlugin
   PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE ${plugin_output})
 
-set(PATH_TO_PLUGIN "${plugin_output}")
-configure_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/Aqt/Testing/qmldir.in"
-  "${CMAKE_CURRENT_SOURCE_DIR}/Aqt/Testing/qmldir"
-  @ONLY)
-unset(PATH_TO_PLUGIN)
-
 file(GLOB files "${CMAKE_CURRENT_SOURCE_DIR}/test-*.qml")
 
 set(i 0)
 foreach(filename ${files})
   add_test(NAME "IntegrationTest_${i}"
-           COMMAND "${QMLTESTRUNNER_APP}" -import "${PROJECT_SOURCE_DIR}/qml"
+           COMMAND "${QMLTESTRUNNER_APP}"
                                  -import "${CMAKE_CURRENT_SOURCE_DIR}"
+                                 -import "${PLUGIN_INSTALL_DIR}"
                                  -input "${filename}"
            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/tests")
   math(EXPR i "${i} + 1")
 endforeach()
+
+install(TARGETS AqtTestUtilsPlugin
+  LIBRARY DESTINATION "${PLUGIN_INSTALL_DIR}/Aqt/Testing")
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/tests/Aqt"
+  DESTINATION "${PLUGIN_INSTALL_DIR}"
+  FILES_MATCHING REGEX "(qmldir|(.*\\.(qml|js)))$")


### PR DESCRIPTION
We remove the dynamic/rewritten qmldirs to make integration a little easier.