### PR TITLE
Update cpp-peglib to make it build with more versions of clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - CONFIGURATION=Release
 
 install:
-  - brew install qt5
+  - HOMEBREW_NO_AUTO_UPDATE=1 brew install qt5
   - export PATH=/usr/local/opt/qt5/bin:$PATH
 
 before_script:


### PR DESCRIPTION
This is not the current master, but it removes the `enabler` variable
that led to an undefined reference with more versions of clang beyond
version 5.

https://github.com/yhirose/cpp-peglib/blob/559836cda1/peglib.h