### PR TITLE
Fixes and improvements when using MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(StyleSheets_VERSION_MINOR 1)
 
 # Enable C++11
 include(CheckCXXCompilerFlag)
-if(WIN32)
+if(MSVC)
   # Check if we are using Visual Studio 2015 or later
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
     message(FATAL_ERROR "You are using an unsupported Windows compiler! (Visual C++ 2015 or later required)")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,10 @@ add_library(StylePlugin MODULE
 )
 target_link_libraries(StylePlugin StyleSheetParser Qt5::Quick)
 
+if(WIN32)
+  set_target_properties(StylePlugin PROPERTIES PREFIX "")
+endif()
+
 set(plugin_output "${PROJECT_BINARY_DIR}/output")
 set_target_properties(StylePlugin
   PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${plugin_output})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,10 @@ target_compile_options(AqtTestUtilsPlugin
 target_link_libraries(AqtTestUtilsPlugin
   Qt5::Qml Qt5::Test Qt5::QuickTest)
 
+if(WIN32)
+  set_target_properties(StylePlugin PROPERTIES PREFIX "")
+endif()
+
 set(plugin_output "${PROJECT_BINARY_DIR}/output")
 set_target_properties(AqtTestUtilsPlugin
   PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${plugin_output})


### PR DESCRIPTION
I wanted to integrate your plugin into our application and came across some issues when using MinGW to build your project:

- The CMake check for the VS compiler version also rejected the MinGW compiler
   Being on a Windows OS does not automatically mean that Visual Studio compiler is used. If the compiler is MinGW's gcc for example the check for the Visual Studio compiler version wouldn't have allowed this. This is now fixed by checking for `MSVC` instead of `WIN32` before checking the actual version of the compiler

- Because the resulting DLLs were named incorrectly the QML Engine wouldn't recognize them
   When compiling the plugin with MinGW on Windows the output name of the resulting libraries (DLLs) always starts with "lib". However, in order for the QML engine to find the plugin DLLs they have to be named exactly as specified in the `qmldir` file, that is without any prefix just 'StylePlugin.dll' respectively 'AqtTestUtilsPlugin.dll'

