### PR TITLE
Fix that '#' was not allowed in CSS

### DIFF
--- a/src/CssParser.cpp
+++ b/src/CssParser.cpp
@@ -189,7 +189,7 @@ StyleSheet parseStdString(const std::string& data)
                           [](const SemanticValues& sv) { return sv.token(); };
 
   IDENT_INIT_CHAR <= cls("a-zA-Z_");
-  IDENT_CHAR      <= cls("-a-zA-Z0-9_");
+  IDENT_CHAR      <= cls("-#a-zA-Z0-9_");
 
   WS              <= zom(cho(cls(" \t"), END_OF_LINE, COMMENT));
   END             <= cho(END_OF_LINE, END_OF_FILE);


### PR DESCRIPTION
The '#' character is used in CSS as the id selector. Since we're using the stylesheets in our application for QWidgets as well as QML we at least need the parser to not fail when it encounters rules like 
```css
QLabel#nameLabel
{
    /* ... */
}
```

This commit does just that: it allows the '#' character as a valid character for identifiers. This results in the parser not failing on rules like the above anymore. However, the above would be parsed as an identifier with the name "QLabel#nameLabel". I don't think that this is a problem since aqt-stylesheets does not support selecting components by id anyway.